### PR TITLE
Add ActiveSupportExtensionsEnabled to rails config

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -7,6 +7,7 @@ plugins:
   - rubocop-rails
 
 AllCops:
+  ActiveSupportExtensionsEnabled: true
   TargetRubyVersion: <%= RbConfig::CONFIG['RUBY_API_VERSION'] %>
   MaxFilesInCache: 100000
   Exclude:
@@ -15,6 +16,9 @@ AllCops:
     - 'config/boot.rb'
     - 'db/**/*schema.rb'
     - 'db/seeds{.rb,/**/*}'
+
+Performance/DoubleStartEndWith:
+  IncludeActiveSupportAliases: true
 
 Rails:
   Enabled: true


### PR DESCRIPTION
See https://docs.rubocop.org/rubocop/configuration.html#enable-checking-active-support-extensions

Also, one more tiny, active-support-related change: https://docs.rubocop.org/rubocop-performance/cops_performance.html#configurable-attributes-performancedoublestartendwith