### PR TITLE
Require valid type sigils in specs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -467,7 +467,6 @@ Sorbet/ValidSigil:
   # We do suggest that the user type their file as `typed: strict`
   SuggestedStrictness: strict
   Exclude:
-    - '**/spec/**/*'
     - '**/db/migrate/**/*'
     - '**/*.{rake,arb,erb,rabl}'
     - '**/{Gemfile,Rakefile}'


### PR DESCRIPTION
There has been work recently in sorbet to improve understanding of RSpec:

https://github.com/sorbet/sorbet/pull/9119#issuecomment-3367912996

By requiring valid sigils, we can then [auto-bump](https://github.com/Shopify/spoom#change-the-sigil-used-in-files) them via spoom when no type errors result.