### PR TITLE
feat: establish new standard RuboCop configuration, retaining legacy config for existing projects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - config/default.yml
+  - config/default-next.yml
 
 plugins:
   - rubocop-gusto
@@ -35,9 +35,17 @@ Naming/FileName:
   Exclude:
     - 'lib/rubocop-gusto.rb'
 
+# The gem intentionally supports Ruby >= 3.2 while developers run a newer Ruby.
+# TargetRubyVersion reflects the developer's runtime, not the minimum supported version.
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Sorbet:
   Enabled: false
 
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
+# RuboCop cop `MSG` strings conventionally use annotated tokens (`%<foo>s`)
+# because that is what the upstream rubocop gem itself uses for its cop
+# messages. Override only for files that define cops.
+Style/FormatStringToken:
+  Exclude:
+    - 'lib/rubocop/cop/**/*.rb'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ bundle exec rspec spec/rubocop/cop/gusto/some_cop_spec.rb
 # Run a single example by line number
 bundle exec rspec spec/rubocop/cop/gusto/some_cop_spec.rb:42
 
-# Sort cops in a rubocop yml file (required after adding a new cop entry to config/default.yml)
+# Sort cops in a rubocop yml file (required after adding a new cop entry)
 bundle exec rubocop-gusto sort config/default.yml
+bundle exec rubocop-gusto sort config/default-next.yml
 
 # Initialize rubocop-gusto in a consuming project
 bundle exec rubocop-gusto init
@@ -45,8 +46,10 @@ bundle exec rubocop-gusto init
 - `lib/rubocop/cop/rack/` — Custom cops scoped to Rack middleware patterns
 - `lib/rubocop/cop/internal_affairs/` — Cops that lint *this gem's own cops* (enforced in CI on this repo)
 - `lib/rubocop/gusto/` — Supporting library code: `CLI`, `Init`, `ConfigYml`, `Plugin`, `version`
-- `config/default.yml` — The shared RuboCop configuration distributed with this gem
-- `config/rails.yml` — Additional Rails-specific configuration (included by `init` when Rails is detected)
+- `config/default.yml` — The legacy shared RuboCop configuration (used by existing consumers; not actively evolved)
+- `config/rails.yml` — Legacy Rails-specific configuration (included by `init` when Rails is detected)
+- `config/default-next.yml` — The new standard RuboCop configuration; opt-in for projects ready to adopt it
+- `config/rails-next.yml` — Rails-specific companion to `default-next.yml`
 - `spec/rubocop/cop/` — Mirrored spec structure matching `lib/rubocop/cop/`
 
 ## Writing a new cop
@@ -63,7 +66,7 @@ bundle exec rubocop-gusto init
 3. Use `def_node_matcher` / `def_node_search` with `# @!method` YARD annotations for all AST pattern matchers. Two important behaviors to know:
    - Any cop that implements `on_send` should also handle safe navigation (`&.`) — add `alias_method :on_csend, :on_send` unless the cop explicitly does not apply to safe navigation calls.
    - `def_node_search :name?` (with a `?` suffix) returns `true`/`false`, not an Enumerator. Use the result directly as a boolean. Without the `?` suffix it returns an Enumerator.
-4. Add an entry to `config/default.yml` with at minimum a `Description:` key, then run `bundle exec rubocop-gusto sort config/default.yml`.
+4. Add an entry to both `config/default.yml` and `config/default-next.yml` with at minimum a `Description:` key, then run `bundle exec rubocop-gusto sort config/default.yml` and `bundle exec rubocop-gusto sort config/default-next.yml`. When deciding whether to enable, disable, or configure a cop in `default-next.yml`, follow the decision framework in `prompts/update-rubocop-config.md`.
 5. Create a corresponding spec in `spec/rubocop/cop/gusto/<cop_name>_spec.rb`.
 
 ## Writing cop specs

--- a/config/default-next.yml
+++ b/config/default-next.yml
@@ -1,0 +1,701 @@
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
+plugins:
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-sorbet
+
+# Cop configuration in this file is restricted to rules that are broadly
+# consistent with the Ruby ecosystem and the libraries we use internally, or
+# that make our code safer and more future-compatible. Do not add stylistic
+# preferences or project-specific conventions here.
+
+AllCops:
+  TargetRubyVersion: <%= RbConfig::CONFIG['RUBY_API_VERSION'] %>
+  NewCops: disable
+  SuggestExtensions: false
+
+Gusto/BootsnapLoadFile:
+  Description: "Do not use Bootsnap to load files. Use `require` instead."
+
+Gusto/DatadogConstant:
+  Description: "Do not call Datadog directly, use an appropriate wrapper library."
+  Exclude:
+    - "config/application.rb"
+    - "config/initializers/datadog.rb"
+    - "lib/datadog/**/*"
+    - "**/spec/**/*"
+
+Gusto/DiscouragedGem:
+  # Disabled by default — consuming projects should configure Gems with their
+  # own discouraged-gem list. Rails projects should enable this and configure
+  # Gems via config/rails-next.yml.
+  Description: "Flags installation of discouraged gems in Gemfiles and gemspecs."
+  Enabled: false
+  Gems: {}
+
+Gusto/ExecuteMigration:
+  Description: "Do not use `execute` to run raw SQL in migrations. Run the query from a backfill rake task instead."
+  Include:
+    - "db/migrate/*.rb"
+
+Gusto/FactoryClassesOrModules:
+  Description: "Do not define modules or classes in factory directories — they break reloading."
+  Include:
+    - "spec/**/factories/*.rb"
+
+Gusto/MinByMaxBy:
+  # Safe: false because the autocorrect changes behavior: `arr.min(&:count)` is
+  # semantically incorrect (compares arrays by element count rather than value);
+  # `arr.min_by(&:count)` is the intended call. The correction changes semantics.
+  Description: "Checks for the use of `min` or `max` with a proc argument. Use `min_by` or `max_by` instead."
+  Safe: false
+  Severity: error
+
+Gusto/NoMetaprogramming:
+  Description: "Avoid using metaprogramming techniques that make code harder to understand, debug, and maintain."
+  Exclude:
+    - "**/spec/**/*"
+
+Gusto/NoRescueErrorMessageChecking:
+  Description: "Checks for the presence of error message checking within rescue blocks."
+
+Gusto/NoSend:
+  Description: "Do not call a private method via `__send__`."
+  Exclude:
+    - "**/spec/**/*"
+
+Gusto/PaperclipOrAttachable:
+  Description: "No more new Paperclip or Attachable usage. New attachments should use ActiveStorage instead."
+
+Gusto/PerformClassMethod:
+  Description: "Prevents accidental definition of `perform` class methods in Sidekiq workers, which should be instance methods instead."
+
+Gusto/PolymorphicTypeValidation:
+  Description: "Ensures polymorphic relations include a type validation, which is required for Sorbet to generate correct types."
+  Include:
+    - "**/models/**/*.rb"
+
+Gusto/PreferProcessLastStatus:
+  Description: "Prefer using `Process.last_status` instead of the global variables `$?` and `$CHILD_STATUS`."
+
+Gusto/RablExtends:
+  Description: "Disallows the use of `extends` in Rabl templates due to poor caching performance. Inline the templating to generate JSON instead."
+  Include:
+    - "**/*.json.rabl"
+
+Gusto/RailsEnv:
+  Description: "Use feature flags or configuration instead of `Rails.env`."
+
+Gusto/RakeConstants:
+  Description: "Do not define constants in Rake files — they may be `load`ed rather than `require`d, causing redefinition warnings."
+  Include:
+    - "**/*.rake"
+    - "Rakefile"
+
+Gusto/RegexpBypass:
+  # Safe: false because the cop cannot determine whether the regex is used for
+  # security validation or general matching; the correction changes semantics
+  # for multiline strings.
+  Description: "Ensures regular expressions use `\\A` and `\\z` anchors instead of `^` and `$` for security validation."
+  Safe: false
+  Exclude:
+    - "**/spec/**/*"
+
+Gusto/RspecDateTimeMock:
+  Description: "Never mock Date, Time, or DateTime directly in specs. Use Rails Testing Time Helpers such as `freeze_time` and `travel_to` instead."
+  Safe: false
+  Include:
+    - "**/spec/**/*"
+
+Gusto/SidekiqParams:
+  Description: "Sidekiq `perform` methods cannot take keyword arguments."
+
+Gusto/ToplevelConstants:
+  Description: "Prevents top-level constants from being defined outside of explicitly excluded paths such as initializers."
+  Include:
+    - "**/*.rb"
+  Exclude:
+    - "**/bin/*"
+    - "bin/*"
+    - "config/**/*"
+    - "lib/*.rb"
+    - "packs/**/{db/seeds,lib,config/initializers}/**/*"
+    - "script/**/*"
+    - "spec/rails_helper.rb"
+    - "**/spec/support/**/*"
+    - "**/*/spec_helper.rb"
+
+Gusto/UsePaintNotColorize:
+  # SafeAutoCorrect: false because the autocorrect replaces colorize methods
+  # with Paint methods; if Paint is not in the project's dependencies, the
+  # corrected code will raise NameError at runtime.
+  Description: "Use the `paint` gem for terminal color methods instead of `colorize`."
+  SafeAutoCorrect: false
+
+Gusto/VcrRecordings:
+  Description: "VCR must be configured to not record in tests. Use `vcr: {record: :none}`."
+
+Layout/ArgumentAlignment:
+  # Consistent with Layout/ParameterAlignment and
+  # Layout/MultilineMethodCallIndentation: fixed indentation is stable under
+  # renames, whereas aligning with the first argument creates indentation that
+  # silently breaks when the method name or leading arguments change length.
+  # Default upstream: with_first_argument.
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ClassStructure:
+  # Enforces a consistent order of definitions within a class body, which helps
+  # both human readers and AI coding agents reason about and generate code
+  # predictably. Disabled by default upstream.
+  Enabled: true
+
+Layout/FirstArgumentIndentation:
+  # Consistent indentation is simpler to follow and avoids churn when method
+  # names are renamed.
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementIndentation:
+  # Consistent indentation regardless of context.
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementLineBreak:
+  # When an array literal spans multiple lines, the first element must be on its
+  # own line. Combined with FirstArrayElementIndentation: consistent, this ensures
+  # multiline arrays always take the same predictable shape — reducing the surface
+  # area agents and reviewers must reason about. Disabled by default upstream.
+  Enabled: true
+
+Layout/FirstHashElementIndentation:
+  # Consistent indentation regardless of context.
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementLineBreak:
+  # When a hash literal spans multiple lines, the first key must be on its own
+  # line. Same rationale as FirstArrayElementLineBreak.
+  # Disabled by default upstream.
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  # When a method call spans multiple lines, the first argument must be on its
+  # own line. Prevents "first argument on same line as method name" which is
+  # alignment-dependent and causes churn when the method name is renamed.
+  # Disabled by default upstream.
+  Enabled: true
+
+Layout/FirstMethodParameterLineBreak:
+  # When a method definition spans multiple lines, the first parameter must be
+  # on its own line. Same rationale as FirstMethodArgumentLineBreak.
+  # Disabled by default upstream.
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  # RBS inline annotations (`#: (Integer) -> String`) are Sorbet type signatures
+  # consumed via --enable-experimental-rbs-comments
+  # (https://sorbet.org/docs/rbs-support), used at typed: strict in gems such as
+  # https://github.com/rubyatscale/packwerk-extensions. With the upstream default
+  # (AllowRBSInlineAnnotation: false) this cop flags them, and its autocorrect —
+  # which runs under `rubocop -a` — rewrites `#:` to `# :`, silently destroying
+  # the signature.
+  AllowRBSInlineAnnotation: true
+
+Layout/LineLength:
+  # The upstream default of 120 happens to fall near the 95th percentile of
+  # line lengths in production Gusto codebases, but it provides little headroom
+  # for patterns that are routine in high-scale Rails services: Sorbet type
+  # signatures with several typed parameters, long ActiveRecord scope chains,
+  # and descriptive error messages. 150 gives practical breathing room for
+  # these cases while still flagging lines that genuinely need to be broken up.
+  # Default upstream: 120.
+  Max: 150
+
+Layout/MultilineMethodCallIndentation:
+  # Fixed indentation is stable under renames; aligned style breaks silently
+  # when the method name length changes.
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  # Consistent with MultilineMethodCallIndentation: fixed indentation is stable
+  # when operand lengths change, whereas aligned style breaks silently.
+  # Default upstream is aligned.
+  EnforcedStyle: indented
+
+Layout/ParameterAlignment:
+  # Same rationale as multiline method call indentation: fixed indentation
+  # does not break when parameter names or method names are renamed.
+  EnforcedStyle: with_fixed_indentation
+
+Lint/AmbiguousBlockAssociation:
+  # Enabled by default upstream. Spec files are excluded because chained block
+  # matchers (e.g. `expect { }.to change { }.by(1)`) are idiomatic RSpec and
+  # unambiguous in context despite triggering this cop.
+  Exclude:
+    - "**/spec/**/*"
+
+Lint/Debugger:
+  # Recognize `require "debug"` (Ruby 3.1+ stdlib debugger) as a debugger
+  # statement so it is caught alongside byebug/pry.
+  DebuggerRequires:
+    - debug
+
+Lint/SelfAssignment:
+  # `x = x` is always a bug; elevate to error so it is never merged.
+  Severity: error
+
+Lint/SharedMutableDefault:
+  # Default method arguments like `def foo(bar = [])` share the same mutable
+  # object across all calls, causing hard-to-diagnose bugs when the default is
+  # mutated. Disabled by default upstream as a pending cop.
+  Enabled: true
+
+Lint/UnexpectedBlockArity:
+  # A block with the wrong number of parameters is always a bug.
+  Severity: error
+
+Lint/UselessConstantScoping:
+  # Constants defined inside conditionally-reachable or method-local scopes are
+  # not visible to callers in the expected way and typically indicate a logic
+  # error. Disabled by default upstream as a pending cop.
+  Enabled: true
+
+Lint/Void:
+  # Void expressions (e.g. `x + 1` as a statement) are always bugs.
+  # CheckForMethodsWithNoSideEffects: true additionally flags calls to methods
+  # whose return value is discarded when the method has no side effects — the
+  # canonical case being `arr.sort` when `arr.sort!` was intended.
+  Severity: error
+  CheckForMethodsWithNoSideEffects: true
+
+Metrics/AbcSize:
+  # The upstream default of 17 is far too low for large-scale Gusto Rails
+  # applications, flagging a significant fraction of otherwise normal methods.
+  # 40 is calibrated above the 95th percentile across production Gusto
+  # codebases to give headroom for methods with legitimate branching — service
+  # methods handling multiple states, controllers with before-action logic, etc.
+  # Default upstream: 17.
+  Max: 40
+
+Metrics/BlockLength:
+  # Spec files are excluded: describe/context/shared_example blocks are
+  # structured by RSpec conventions and are legitimately long. 40 lines
+  # aligns with Metrics/MethodLength: tasks, Sidekiq perform blocks, and
+  # complex DSL callbacks are effectively methods-in-block-form and should
+  # share the same ceiling. Default upstream: 25.
+  Max: 40
+  Exclude:
+    - "**/spec/**/*"
+
+Metrics/ClassLength:
+  # The upstream default of 100 flags a significant fraction of classes in
+  # large-scale Gusto Rails applications. 175 is calibrated above the 95th
+  # percentile across production Gusto codebases and allows for domain classes
+  # with multiple collaborating methods without flagging ordinary complexity.
+  # Default upstream: 100.
+  Max: 175
+  # Array and hash literals are data, not logic. Counting them inflates the
+  # length metric for data-heavy classes (e.g. carrier rate tables) where the
+  # "class length" signal reflects table size, not code complexity. Each literal
+  # counts as one line so only the surrounding method and assignment code is
+  # measured against the limit.
+  CountAsOne:
+    - array
+    - hash
+
+Metrics/CyclomaticComplexity:
+  # The upstream default of 7 matches the 95th percentile of production Gusto
+  # codebases and is a reasonable ceiling for most methods. 10 gives headroom
+  # for methods with legitimately branchy logic — input validation, state
+  # transitions, multi-condition guards — without permitting deeply nested or
+  # poorly factored code. Default upstream: 7.
+  Max: 10
+
+Metrics/MethodLength:
+  # The upstream default of 10 flags a large fraction of non-test methods in
+  # production Gusto codebases — far too aggressive to be a useful signal.
+  # 40 is calibrated above the 95th percentile across those codebases; methods
+  # longer than 40 lines are outliers that warrant extraction.
+  # Spec files are excluded: setup blocks, let chains, and assertion sequences
+  # are legitimately verbose without being candidates for extraction.
+  # Default upstream: 10.
+  Max: 40
+  Exclude:
+    - "**/spec/**/*"
+
+Metrics/ModuleLength:
+  # The upstream default of 100 flags a large fraction of modules in
+  # production Gusto codebases, making it nearly useless as a signal. 200 is
+  # set above Metrics/ClassLength to reflect that modules are often namespace
+  # containers or concerns with many shared methods — roles that classes do
+  # not typically fill — while still discouraging the accumulation of
+  # unbounded module size seen in legacy codebases. Default upstream: 100.
+  Max: 200
+  # Same rationale as Metrics/ClassLength: array and hash literals are data,
+  # not logic. Counting them inflates the length signal for modules that
+  # contain lookup tables or constant definitions.
+  CountAsOne:
+    - array
+    - hash
+
+Metrics/ParameterLists:
+  # Keyword arguments are self-documenting at the call site (`prefix: "status"`)
+  # and do not create the reasoning burden of positional arguments, where a
+  # reader must mentally map positions to meaning. Excluding them keeps the cop
+  # focused on the genuinely difficult case: long positional argument lists where
+  # callers must supply values in the correct order without contextual labels.
+  # Default upstream: true.
+  CountKeywordArgs: false
+
+Metrics/PerceivedComplexity:
+  # Consistent with Metrics/CyclomaticComplexity. PerceivedComplexity adds
+  # weight for boolean operators, which are common in guard clauses and
+  # validation logic in web services. 10 is a practical ceiling that flags
+  # genuinely hard-to-follow methods without rejecting normal branching code.
+  # Default upstream: 8.
+  Max: 10
+
+Performance/CollectionLiteralInLoop:
+  # Allocating a constant Array, Hash, or Range inside a loop body creates a new
+  # object on every iteration. Extract it to a constant or variable outside the
+  # loop. Disabled by default upstream as a pending cop.
+  Enabled: true
+
+Performance/MapCompact:
+  # `array.map { transform(x) }.compact` allocates an intermediate array before
+  # filtering nils. `filter_map` does both in a single pass. Pending upstream.
+  Enabled: true
+
+Performance/OpenStruct:
+  # OpenStruct is slow (it modifies the Ruby runtime on each instantiation) and
+  # type-unsafe — Sorbet cannot type-check dynamically defined attributes.
+  # Prefer a Struct, Data, or plain Ruby class instead.
+  Enabled: true
+
+Performance/RedundantBlockCall:
+  # This cop's autocorrect removes `&blk` from the parameter list (replacing
+  # `blk.call` with `yield`). In Sorbet-typed code, `&blk` is kept in the
+  # parameter list to type the block in a sig, e.g.:
+  #   sig { params(blk: T.proc.void).void }
+  #   def foo(&blk) = blk.call
+  # Removing `&blk` would orphan the `params(blk:)` declaration and break the
+  # sig. Disabling the cop prevents both the false-positive offense and the
+  # autocorrect-induced sig breakage. Enabled by default upstream.
+  Enabled: false
+
+Performance/RedundantSortBlock:
+  # `array.sort { |a, b| a <=> b }` is identical to `array.sort` — the block
+  # just reimplements the default comparator. Pending upstream.
+  Enabled: true
+
+Performance/SelectMap:
+  # Prefer `filter_map` over `.select { }.map { }` chains — it is more concise,
+  # more expressive, and avoids allocating an intermediate array.
+  Enabled: true
+
+Performance/StringInclude:
+  # `string.match?(/literal_substring/)` invokes the regex engine unnecessarily.
+  # `string.include?('literal_substring')` is faster and clearer for plain
+  # string patterns. Pending upstream.
+  Enabled: true
+
+Performance/ZipWithoutBlock:
+  # `array.zip(other)` without a block allocates an array of arrays as the
+  # return value. Passing a block avoids that intermediate allocation.
+  # Disabled by default upstream as a pending cop.
+  Enabled: true
+
+RSpec/DescribeClass:
+  # IgnoredMetadata lets non-unit specs (request, system, integration, etc.)
+  # use a string description without triggering this cop, while unit specs
+  # still have to reference a class constant. Mark non-unit describe blocks
+  # with the appropriate `type:` metadata (e.g. `type: :integration`).
+  # The list below extends the upstream Rails defaults with :integration for
+  # CLI and end-to-end specs. Enabled by default upstream; kept enabled.
+  IgnoredMetadata:
+    type:
+      - aruba
+      - channel
+      - controller
+      - feature
+      - helper
+      - integration
+      - job
+      - mailbox
+      - mailer
+      - model
+      - request
+      - routing
+      - system
+      - task
+      - view
+
+RSpec/DescribedClass:
+  # `described_class` is incompatible with Sorbet: constant resolution happens
+  # before type resolution, so `described_class::SomeConstant` always fails with
+  # error 5002 ("Unable to resolve constant"). Sorbet won't fix this because
+  # dynamic constant references are unsupported by design:
+  # https://github.com/sorbet/sorbet/issues/10031
+  #
+  # The RSpec maintainer has also called it an anti-pattern: `described_class`
+  # is a misnomer — it returns whatever was passed to `describe`, not necessarily
+  # a class — and has proposed its removal:
+  # https://github.com/rspec/rspec/issues/31#issuecomment-2504679808
+  Enabled: false
+
+RSpec/DescribedClassModuleWrapping:
+  # This cop flags module-wrapped describe blocks and prefers fully-qualified
+  # constant names (e.g. `RSpec.describe MyModule::MyClass`). For Sorbet-typed
+  # specs the reverse is correct: wrapping describe blocks inside a module lets
+  # Sorbet resolve constants relative to that namespace, whereas top-level
+  # describes require fully-qualified constant paths everywhere inside the block,
+  # which Sorbet can fail to resolve in certain contexts.
+  #
+  # The cop has no "enforce wrapping" mode, so we only disable the incompatible
+  # direction. Disabled by default upstream, but made explicit here to document
+  # the deliberate choice.
+  Enabled: false
+
+RSpec/ExampleLength:
+  # The upstream default of 5 lines per example is far too restrictive for
+  # production Gusto test suites. 20 gives adequate headroom for integration
+  # and setup-heavy examples without permitting runaway tests. Default upstream: 5.
+  Max: 20
+
+RSpec/MultipleExpectations:
+  # The upstream default of 1 expectation per example is too restrictive for
+  # production Gusto test suites. 8 is calibrated to cover integration examples
+  # that verify several outcomes of a single operation. Default upstream: 1.
+  Max: 8
+
+RSpec/MultipleMemoizedHelpers:
+  # The upstream default of 5 memoized helpers per example group is too
+  # restrictive for production Gusto test suites. 30 is calibrated at the
+  # 95th percentile across those codebases. Default upstream: 5.
+  Max: 30
+
+RSpec/NamedSubject:
+  # The upstream `always` style requires every subject to be named, even
+  # trivial anonymous subjects (`subject { Thing.new }`). At scale this
+  # produces tens of thousands of violations in codebases that legitimately
+  # use anonymous subjects for one-liner specs. The `named_only` style
+  # addresses the actually-inconsistent case: a subject defined with a name
+  # (`subject(:widget) { Widget.new }`) that is then accessed via the generic
+  # `subject` or `is_expected` instead of the given name. Default upstream:
+  # always (EnforcedStyle).
+  EnforcedStyle: named_only
+
+RSpec/NestedGroups:
+  # The upstream default of 3 levels is too restrictive for specs that test
+  # hierarchical behavior — for example, a Danger plugin spec that branches on
+  # migration type, then file type, then diff type naturally reaches 5 levels.
+  # Each level adds genuine context that would be lost if flattened. 5 is a
+  # practical ceiling that allows well-structured deep specs while discouraging
+  # indiscriminate nesting. Default upstream: 3.
+  Max: 5
+
+Sorbet/ForbidTAnyWithNil:
+  # `T.any(NilClass, X)` is the non-idiomatic form of `T.nilable(X)`. The two
+  # are semantically identical, but `T.nilable` is the Sorbet convention,
+  # produces clearer error messages, and matches what Tapioca generates.
+  # Pending upstream.
+  Enabled: true
+
+Sorbet/ForbidTUnsafe:
+  # `T.unsafe` completely disables Sorbet typechecking on its argument, turning a
+  # static type error into a latent runtime error. New services maintain strict
+  # typing (see Sorbet/StrictSigil); the escape hatch undermines that guarantee.
+  # Prefer `T.cast`, an RBI shim, or restructuring. Disabled by default upstream.
+  Enabled: true
+
+Sorbet/Refinement:
+  # Ruby refinements (`refine`/`using`) are not supported by Sorbet's static
+  # analysis — Sorbet cannot see through activated refinements and will produce
+  # incorrect type results. This cop was contributed by Gusto and is still marked
+  # pending upstream; we enable it explicitly.
+  Enabled: true
+
+Sorbet/StrictSigil:
+  # New services should maintain `typed: strict` or higher on all production
+  # files, enforcing full Sorbet coverage from day one. Files that cannot yet
+  # meet the strict bar should be tracked as explicit technical debt rather than
+  # silently left untyped. Disabled by default upstream.
+  Enabled: true
+  Exclude:
+    - "bin/**/*"
+    - "db/**/*.rb"
+    - "script/**/*"
+    - "spec/**/*"
+
+Sorbet/ValidSigil:
+  # Require every file to carry a Sorbet sigil so no file is silently treated as
+  # `typed: false`. Without RequireSigilOnAllFiles: true, files that omit a sigil
+  # are invisible to Sorbet and fall outside its safety guarantees.
+  # SuggestedStrictness: strict nudges authors toward full typing when the
+  # autocorrect runs.
+  # Default upstream has RequireSigilOnAllFiles: false.
+  RequireSigilOnAllFiles: true
+  SuggestedStrictness: strict
+  Exclude:
+    - "bin/**/*"
+    - "db/migrate/**/*.rb"
+    - "**/*.{rake,erb}"
+    - "**/Gemfile"
+    - "**/Rakefile"
+
+Style/AccessModifierDeclarations:
+  # Inline access modifiers (`private def foo`) make visibility impossible to
+  # misplace: agents have been observed putting methods in the wrong visibility
+  # block (e.g. a public method inside a `private` group) with no static signal
+  # until CI fails. Inline modifiers eliminate that class of error entirely.
+  # Layout/ClassStructure already enforces grouping of methods by visibility, so
+  # the organizational benefit of group-style modifiers is provided there.
+  # Default upstream is group.
+  EnforcedStyle: inline
+
+Style/Alias:
+  # `alias_method` works everywhere (including inside `class << self` blocks);
+  # `alias` is lexically scoped and behaves unexpectedly in subclasses.
+  # `alias_method` is the Rails and OOP convention.
+  EnforcedStyle: prefer_alias_method
+
+Style/ArgumentsForwarding:
+  # The `...` forwarding syntax is not supported by Sorbet's static analysis —
+  # Sorbet cannot infer types for forwarded arguments and will raise an error.
+  # Use explicit `*args, **kwargs, &blk` parameters instead.
+  # Marked pending upstream; disabling here prevents future auto-enablement.
+  Enabled: false
+
+Style/AsciiComments:
+  # Allow Unicode in comments. Em-dashes (—), arrows (→), and other Unicode
+  # characters are increasingly common in modern Ruby comments and improve
+  # clarity over ASCII approximations. Files are UTF-8 by default; restricting
+  # comments to ASCII serves no correctness or portability purpose.
+  Enabled: false
+
+Style/AutoResourceCleanup:
+  # Prefer the block form of resource-opening methods (e.g. `File.open`)
+  # to ensure resources are always closed, even if an exception is raised.
+  Enabled: true
+
+Style/ClassAndModuleChildren:
+  # The unsafe autocorrect produces broken code when `described_class` is used
+  # as a namespace prefix (`class described_class::Foo`), because it treats
+  # `described_class` as a module constant and unnests it. However, the correct
+  # resolution is to replace `described_class` with the actual class name —
+  # which is consistent with `RSpec/DescribedClass: Enabled: false` and removes
+  # a pattern the RSpec maintainer has called an anti-pattern. SafeAutoCorrect
+  # is already false upstream; the cop itself is left enabled so the offense is
+  # reported and authors use the explicit class name instead.
+  # Enabled by default upstream; kept enabled.
+  Enabled: true
+
+Style/CommandLiteral:
+  # `%x()` is visually distinct from string literals, making shell command
+  # invocations easy to spot during code review. Backtick strings are easy to
+  # miss and are an injection risk if not carefully reviewed.
+  EnforcedStyle: percent_x
+
+Style/Documentation:
+  # Agents are the primary readers and writers of this codebase. A class-level
+  # documentation comment lets an agent ingest the purpose of a class directly
+  # rather than inferring it from the class body — avoiding POSIWID reasoning
+  # where the agent concludes the class does what it observes it doing, rather
+  # than what it was intended to do. Enabled by default upstream; kept enabled.
+  Enabled: true
+
+Style/FetchEnvVar:
+  # `ENV['KEY']` returns `nil` silently for missing keys, allowing
+  # misconfiguration to propagate through the application as unexpected nil
+  # values. `ENV.fetch('KEY')` raises `KeyError` immediately, surfacing missing
+  # configuration at startup rather than at the call site. Use
+  # `ENV.fetch('KEY', nil)` for genuinely optional variables. Pending upstream.
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  # Ruby 3.4 introduced "chilled strings" as a stepping stone toward making
+  # frozen string literals the default. Files with `# frozen_string_literal: true`
+  # are already fully frozen and forward-compatible with this transition.
+  # See: https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
+  EnforcedStyle: always_true
+
+Style/HashSyntax:
+  # Prevent mixed hash syntax (`{a: 1, :b => 2}`) which is confusing regardless
+  # of individual key choices.
+  EnforcedStyle: ruby19_no_mixed_keys
+  # Require shorthand `{user:}` whenever the key matches the local/method name.
+  # Upstream default is `either`, which permits mixed forms within a single
+  # hash and produces inconsistent agent output across the codebase. `always`
+  # gives a single canonical shape — one valid form per key/value pair —
+  # which maximizes uniform agent output and minimizes diff churn. This is
+  # stricter than mainstream Ruby style guides (Standard, Shopify, and Rails
+  # all leave `Style/HashSyntax` permissive); the choice rests on reviewability
+  # and agent-consistency priorities rather than ecosystem convergence.
+  # Autocorrect is purely syntactic and safe.
+  EnforcedShorthandSyntax: always
+
+Style/IfUnlessModifier:
+  # The modifier form is idiomatic for simple guards (`return if x.nil?`) but
+  # the cop cannot distinguish simple conditions from complex compound ones.
+  # Converting `if long_condition_a && long_condition_b\n  action\nend` to
+  # `action if long_condition_a && long_condition_b` buries the condition at
+  # the end of a long line, making code harder to scan. Agents already write
+  # guard-clause modifier forms naturally without enforcement. Enabled upstream.
+  Enabled: false
+
+Style/Lambda:
+  # Enforce `->` everywhere for consistency. `lambda {}` is the legacy form;
+  # `->` is more concise and works well with Sorbet type annotations.
+  EnforcedStyle: literal
+
+Style/ModuleFunction:
+  # Sorbet does not enforce the singleton version of module function methods:
+  # https://github.com/sorbet/sorbet/issues/8531
+  # Even if it did, requiring the code to typecheck both paths would be a pain
+  # for maintainability. It's also better for code to be explicit about which
+  # version of the method is being called, as it is one fewer decision the
+  # downstream developer has to make.
+  EnforcedStyle: forbidden
+
+Style/PercentLiteralDelimiters:
+  # Prefer square-bracket delimiters (`%w[a b c]`) over the upstream default
+  # of parentheses. Square brackets visually echo the array literal `[a, b, c]`
+  # and are the convention adopted by Standard Ruby and most modern style
+  # guides. Agents naturally emit `%w[...]`; matching that reduces autocorrect
+  # churn and aligns with the form the wider ecosystem has converged on.
+  PreferredDelimiters:
+    default: "[]"
+    "%i": "[]"
+    "%I": "[]"
+    "%w": "[]"
+    "%W": "[]"
+
+Style/RedundantSelf:
+  # `self.foo` makes explicit that `foo` is a method call rather than a local
+  # variable, which is valuable for readability and code review — especially in
+  # class methods where `self.ignored_columns =` and `ignored_columns =` have
+  # different semantics (the latter creates a local variable, not a setter call).
+  # Removing self systematically trades that signal for no functional benefit.
+  # Enabled upstream.
+  Enabled: false
+
+Style/StringLiterals:
+  # Rails convention and the broader Rails ecosystem use double-quoted strings.
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInArguments:
+  # Trailing commas on multiline argument lists reduce diff noise: adding a new
+  # last argument only requires one line change instead of two.
+  # Default upstream is no_comma.
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  # Trailing commas on multiline literals reduce diff noise: adding a new last
+  # element only requires one line change instead of two.
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  # Same rationale as Style/TrailingCommaInArrayLiteral.
+  EnforcedStyleForMultiline: consistent_comma

--- a/config/rails-next.yml
+++ b/config/rails-next.yml
@@ -1,0 +1,161 @@
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
+plugins:
+  - rubocop-rails
+
+# Cop configuration in this file is restricted to rules that are broadly
+# consistent with the Ruby ecosystem and the libraries we use internally, or
+# that make our code safer and more future-compatible. Do not add stylistic
+# preferences or project-specific conventions here.
+
+AllCops:
+  ActiveSupportExtensionsEnabled: true
+
+Gusto/DiscouragedGem:
+  # Enable in Rails projects with a baseline list of discouraged gems.
+  # Timecop is discouraged because Rails ships built-in time helpers
+  # (`freeze_time`, `travel_to`) that achieve the same result without an
+  # external dependency. Adding it here ensures new Rails services do not
+  # accidentally introduce it.
+  Enabled: true
+  Include:
+    - "**/*.gemspec"
+    - "**/Gemfile"
+  Gems:
+    timecop: "Use Rails' time helpers (e.g., freeze_time, travel_to) instead of Timecop."
+
+Performance/DoubleStartEndWith:
+  # Rails ActiveSupport adds `starts_with?` and `ends_with?` as aliases.
+  # Without this setting, `str.starts_with?("a") || str.starts_with?("b")`
+  # is not flagged even though it should be `str.starts_with?("a", "b")`.
+  # Default upstream: false.
+  IncludeActiveSupportAliases: true
+
+Rails/ActionControllerFlashBeforeRender:
+  # `flash[:notice] = 'msg'; render :edit` sets the flash for the *next* request,
+  # not the current render. Use `flash.now[:notice]` when rendering without
+  # redirecting so the message appears on the current response.
+  # Pending upstream.
+  Enabled: true
+
+Rails/ActionOrder:
+  # Enforces the canonical REST action order within controllers:
+  # index, show, new, edit, create, update, destroy. Consistent ordering reduces
+  # cognitive overhead and ensures agents generate controllers in the same shape
+  # across services. Pending upstream.
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  # When a model defines `after_commit :callback` (or its aliases
+  # `after_create_commit`, `after_update_commit`, `after_destroy_commit`)
+  # more than once with the same callback name, the later definition silently
+  # replaces the earlier one. Enforce at most one callback registration per name.
+  # Pending upstream.
+  Enabled: true
+
+Rails/DefaultScope:
+  # default_scope silently modifies every query on the model, including
+  # associations, joins, and attempts to escape via `.unscoped` — which strips
+  # ALL conditions, not just the default scope, causing full table scans and
+  # incorrect results. For example, `.where(...).unscoped` on a model with
+  # default_scope discards the where clause entirely, potentially returning
+  # incorrect results and scanning the full table unnecessarily.
+  #
+  # Use explicitly named scopes applied at the call site instead.
+  Enabled: true
+
+Rails/DuplicateAssociation:
+  # Defining the same association twice (e.g. two `has_many :tags` calls) causes
+  # the second definition to silently replace the first, leading to confusing
+  # runtime behavior. Pending upstream.
+  Enabled: true
+
+Rails/DuplicateScope:
+  # Two named scopes sharing the same name — the later definition silently
+  # overrides the earlier one. Pending upstream.
+  Enabled: true
+
+Rails/EagerEvaluationLogMessage:
+  # Logger calls with string interpolation always evaluate the interpolated
+  # expression even when the log level is not active, e.g.
+  # `Rails.logger.debug "val=#{expensive_call}"` runs `expensive_call` regardless
+  # of whether debug logging is enabled. Use a block to defer evaluation:
+  # `Rails.logger.debug { "val=#{expensive_call}" }`.
+  # Disabled by default upstream as a pending cop.
+  Enabled: true
+
+Rails/IgnoredColumnsAssignment:
+  # `self.ignored_columns = [...]` replaces the inherited list, silently
+  # un-ignoring any columns added by a parent class. Use
+  # `self.ignored_columns += [...]` to extend rather than replace.
+  # Disabled by default upstream as a pending cop.
+  Enabled: true
+
+Rails/Pluck:
+  # `scope.map(&:column)` loads all records into memory before extracting values.
+  # `scope.pluck(:column)` issues a targeted `SELECT column` query. The cop
+  # targets ActiveRecord scopes specifically and does not flag plain array usage.
+  # Pending upstream.
+  Enabled: true
+
+Rails/RedundantPresenceValidationOnBelongsTo:
+  # Since Rails 5, `belongs_to` validates presence by default. Adding
+  # `validates :association, presence: true` is redundant and suggests
+  # the author is not aware of this default. Pending upstream.
+  Enabled: true
+
+Rails/ReversibleMigrationMethodDefinition:
+  # Ensures every migration implements either `change` or both `up` and `down`,
+  # so migrations can always be rolled back safely.
+  Enabled: true
+
+Rails/SafeNavigation:
+  # `try` is inherently untypable — invoking arbitrary methods on arbitrary
+  # objects cannot be statically verified and leads to unmaintainable code.
+  # Prefer the safe navigation operator (`&.`) which is explicit about the
+  # receiver type and works correctly with Sorbet.
+  ConvertTry: true
+  SafeAutoCorrect: false
+
+Rails/SaveBang:
+  # `save`, `update`, and related non-bang AR methods return `false` on failure
+  # without raising. Callers that ignore the return value silently swallow
+  # validation failures and data integrity errors. Prefer the bang forms
+  # (`save!`, `update!`) which raise `ActiveRecord::RecordInvalid` on failure,
+  # making the failure impossible to ignore.
+  # Disabled by default upstream.
+  Enabled: true
+  SafeAutoCorrect: false
+
+Rails/TimeZone:
+  # Strict mode requires `Time.current`, `Time.zone.parse(...)`, and other
+  # timezone-aware methods instead of `Time.now`, `Time.parse(...)`, etc.
+  # New services should be timezone-correct from day one — retrofitting
+  # timezone awareness into an existing codebase is expensive.
+  # Default upstream: flexible.
+  EnforcedStyle: strict
+
+Rails/TransactionExitStatement:
+  # Using `return`, `break`, or `throw` inside an ActiveRecord transaction block
+  # causes the transaction to commit rather than roll back, even when the intent
+  # is to abort the operation. Raise an exception to abort a transaction instead.
+  # Pending upstream.
+  Enabled: true
+
+Rails/WhereEquals:
+  # `where("column = ?", value)` is the SQL-string form of a simple equality
+  # condition. `where(column: value)` is equivalent, more readable, and
+  # eliminates a class of SQL construction errors. Reserve the string form for
+  # complex expressions that cannot be expressed as hash conditions.
+  # Pending upstream.
+  Enabled: true
+
+Rails/WhereNotWithMultipleConditions:
+  # `where.not(a: 1, b: 2)` generates `WHERE NOT (a = 1 AND b = 2)`, which by
+  # De Morgan's law is equivalent to `WHERE a != 1 OR b != 2`. Most callers
+  # intend `WHERE a != 1 AND b != 2`. Use separate `where.not` calls for each
+  # condition to make the intent explicit. Pending upstream.
+  Enabled: true

--- a/lib/rubocop/cop/gusto/bootsnap_load_file.rb
+++ b/lib/rubocop/cop/gusto/bootsnap_load_file.rb
@@ -3,10 +3,28 @@
 module RuboCop
   module Cop
     module Gusto
-      # Do not use Bootsnap to load files. Use `require` instead.
+      # Checks for calls to `YAML.load` or `JSON.load` that receive a
+      # `File.read` argument, and for `YAML.load` or `JSON.load` called
+      # inside a `File.open` block. These patterns bypass Bootsnap's file
+      # caching. Use `YAML.load_file` or `JSON.load_file` instead so that
+      # Bootsnap can cache the parsed result and speed up boot time.
+      #
+      # @example
+      #   # bad
+      #   YAML.load(File.read('config/settings.yml'))
+      #   JSON.load(File.read('data/records.json'))
+      #
+      #   File.open('config/settings.yml') do |f|
+      #     YAML.load(f)
+      #   end
+      #
+      #   # good
+      #   YAML.load_file('config/settings.yml')
+      #   JSON.load_file('data/records.json')
+      #
       class BootsnapLoadFile < Base
         PROHIBITED_CONSTANTS = Set[:YAML, :JSON].freeze
-        RESTRICT_ON_SEND = %i(load).freeze
+        RESTRICT_ON_SEND = %i[load].freeze
 
         # @!method yaml_or_json_load(node)
         def_node_matcher :yaml_or_json_load, "(send $(const nil? PROHIBITED_CONSTANTS) :load ...)"
@@ -42,10 +60,8 @@ module RuboCop
           end
         end
 
-        private
-
         # Look for File.read as the first argument
-        def on_load(node, constant_node)
+        private def on_load(node, constant_node)
           return unless node.first_argument
 
           file_read(node.first_argument) do |read_file_node|

--- a/lib/rubocop/cop/gusto/datadog_constant.rb
+++ b/lib/rubocop/cop/gusto/datadog_constant.rb
@@ -3,6 +3,20 @@
 module RuboCop
   module Cop
     module Gusto
+      # Checks for direct references to the `Datadog` constant. Call sites
+      # should use an internal wrapper library so that the underlying
+      # instrumentation provider can be swapped without touching application
+      # code. Direct usage is permitted in the Datadog initializer and its
+      # supporting library files.
+      #
+      # @example
+      #   # bad
+      #   Datadog::Statsd.new('localhost', 8125)
+      #   Datadog.configure { |c| c.use :rails }
+      #
+      #   # good
+      #   Monitoring.increment('my.counter')  # via the internal wrapper
+      #
       class DatadogConstant < Base
         MSG = "Do not call Datadog directly, use an appropriate wrapper library."
         NAMESPACE = "Datadog"

--- a/lib/rubocop/cop/gusto/discouraged_gem.rb
+++ b/lib/rubocop/cop/gusto/discouraged_gem.rb
@@ -3,25 +3,34 @@
 module RuboCop
   module Cop
     module Gusto
-      # Flags installation of discouraged gems (e.g., timecop) in Gemfiles and gemspecs.
+      # Flags installation of gems that have been explicitly discouraged in
+      # favor of a preferred alternative. The set of discouraged gems and the
+      # advice message for each is configurable via the `Gems` option.
+      # Rails projects should enable this cop via `config/rails.yml`, which
+      # ships a default `Gems` list (e.g. banning `timecop`).
       #
-      # Configuration:
-      #   Gems:
-      #     timecop: "Use Rails' time helpers (e.g., freeze_time, travel_to) instead of Timecop."
+      # @example Gems: { timecop: "Use Rails' time helpers instead." }
+      #   # bad — Gemfile
+      #   gem 'timecop'
+      #   gem :timecop
       #
-      # This cop is intended to be enabled in Rails projects via config/rails.yml.
+      #   # bad — .gemspec
+      #   spec.add_dependency 'timecop'
+      #   spec.add_development_dependency 'timecop', '~> 0.9'
+      #
+      #   # good — Gemfile
+      #   # (use freeze_time or travel_to from Rails instead)
+      #
       class DiscouragedGem < Base
-        MSG = "Avoid using the '%{gem}' gem. %{advice}"
+        MSG = "Avoid using the '%<gem>s' gem. %<advice>s"
 
-        RESTRICT_ON_SEND = %i(gem add_dependency add_development_dependency).freeze
+        RESTRICT_ON_SEND = %i[gem add_dependency add_development_dependency].freeze
 
         def on_send(node)
           check_gem_usage(node)
         end
 
-        private
-
-        def check_gem_usage(node)
+        private def check_gem_usage(node)
           return unless node.first_argument&.type?(:str, :sym)
           return unless discouraged_gems.include?(node.first_argument.value.to_s)
 
@@ -29,19 +38,19 @@ module RuboCop
           # No autocorrect: removing dependencies is a project decision.
         end
 
-        def discouraged_gems
+        private def discouraged_gems
           @discouraged_gems ||= gems_config.keys.map(&:to_s)
         end
 
-        def message_for(gem)
-          format(MSG, gem: gem, advice: advice_for(gem))
+        private def message_for(gem)
+          format(MSG, gem:, advice: advice_for(gem))
         end
 
-        def advice_for(gem)
+        private def advice_for(gem)
           gems_config[gem]
         end
 
-        def gems_config
+        private def gems_config
           cop_config["Gems"] || {}
         end
       end

--- a/lib/rubocop/cop/gusto/execute_migration.rb
+++ b/lib/rubocop/cop/gusto/execute_migration.rb
@@ -3,8 +3,38 @@
 module RuboCop
   module Cop
     module Gusto
+      # Checks for calls to `execute` inside database migrations. Running
+      # arbitrary SQL via `execute` is risky: it bypasses ActiveRecord
+      # validations and callbacks, can cause long-running table locks on
+      # large datasets, and is difficult to roll back safely. Use
+      # `add_column`/`change_column` with appropriate options instead, or
+      # move data backfills into a separate rake task.
+      #
+      # @example
+      #   # bad
+      #   class BackfillUserStatus < ActiveRecord::Migration[7.0]
+      #     def change
+      #       execute("UPDATE users SET status = 'active' WHERE status IS NULL")
+      #     end
+      #   end
+      #
+      #   # good — use a column default for schema changes
+      #   class AddStatusToUsers < ActiveRecord::Migration[7.0]
+      #     def change
+      #       add_column :users, :status, :string, default: 'active', null: false
+      #     end
+      #   end
+      #
+      #   # good — move data changes to a backfill rake task
+      #   # lib/tasks/backfill_user_status.rake
+      #   task backfill_user_status: :environment do
+      #     User.where(status: nil).update_all(status: 'active')
+      #   end
+      #
       class ExecuteMigration < Base
-        MSG = "Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method."
+        MSG = "Do not use `execute` to run raw SQL in a migration. " \
+              "Run the query from a backfill rake task or pass the SQL options to the " \
+              "`add_column`/`change_column` method."
         RESTRICT_ON_SEND = [:execute].freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/gusto/factory_classes_or_modules.rb
+++ b/lib/rubocop/cop/gusto/factory_classes_or_modules.rb
@@ -3,6 +3,30 @@
 module RuboCop
   module Cop
     module Gusto
+      # Checks for class or module definitions inside factory directories.
+      # Factory files are `require`d once at startup and are not reloaded by
+      # Rails' code reloader. Constants defined inside them become stale
+      # between reloads or cause "already initialized constant" warnings when
+      # the test suite is run more than once in the same process.
+      # Move shared test helpers to `spec/support/` instead.
+      #
+      # @example
+      #   # bad — spec/factories/users.rb
+      #   module UserHelpers
+      #     def admin_user = create(:user, role: :admin)
+      #   end
+      #
+      #   FactoryBot.define { factory :user }
+      #
+      #   # good — move the module out of the factory directory
+      #   # spec/support/user_helpers.rb
+      #   module UserHelpers
+      #     def admin_user = create(:user, role: :admin)
+      #   end
+      #
+      #   # spec/factories/users.rb
+      #   FactoryBot.define { factory :user }
+      #
       class FactoryClassesOrModules < Base
         MSG = "Do not define modules or classes in factory directories - they break reloading"
 

--- a/lib/rubocop/cop/gusto/min_by_max_by.rb
+++ b/lib/rubocop/cop/gusto/min_by_max_by.rb
@@ -26,8 +26,8 @@ module RuboCop
       class MinByMaxBy < Base
         extend AutoCorrector
 
-        MSG = "Use `%{method}_by` instead of `%{method}` with a proc like `&:my_method_proc`. `%{method}` expects Comparable elements."
-        RESTRICT_ON_SEND = %i(min max).freeze
+        MSG = "Use `%<method>s_by` instead of `%<method>s` with a proc like `&:my_method_proc`. `%<method>s` expects Comparable elements."
+        RESTRICT_ON_SEND = %i[min max].freeze
 
         def on_send(node)
           return unless node.arguments?

--- a/lib/rubocop/cop/gusto/no_metaprogramming.rb
+++ b/lib/rubocop/cop/gusto/no_metaprogramming.rb
@@ -55,7 +55,7 @@ module RuboCop
       #   end
       #
       class NoMetaprogramming < Base
-        RESTRICT_ON_SEND = %i(define_method instance_eval define_singleton_method class_eval).freeze
+        RESTRICT_ON_SEND = %i[define_method instance_eval define_singleton_method class_eval].freeze
 
         # @!method included_definition?(node)
         def_node_matcher :included_definition?, <<~PATTERN
@@ -110,19 +110,35 @@ module RuboCop
 
         def on_send(node)
           using_define_method?(node) do
-            add_offense(node, message: "Please do not define methods dynamically, instead define them using `def` and explicitly. This helps readability for both humans and machines.")
+            add_offense(
+              node,
+              message: "Please do not define methods dynamically, instead define them using " \
+                       "`def` and explicitly. This helps readability for both humans and machines.",
+            )
           end
 
           using_define_singleton_method_on_klass_instance?(node) do
-            add_offense(node, message: "Please do not use define_singleton_method. Instead, define the method explicitly using `def self.my_method; end`")
+            add_offense(
+              node,
+              message: "Please do not use define_singleton_method. Instead, define the method " \
+                       "explicitly using `def self.my_method; end`",
+            )
           end
 
           using_instance_eval?(node) do
-            add_offense(node, message: "Please do not use instance_eval to augment behavior onto an instance. Instead, define the method you want to use in the class definition.")
+            add_offense(
+              node,
+              message: "Please do not use instance_eval to augment behavior onto an instance. " \
+                       "Instead, define the method you want to use in the class definition.",
+            )
           end
 
           using_class_eval?(node) do
-            add_offense(node, message: "Please do not use class_eval to augment behavior onto a class. Instead, define the method you want to use in the class definition.")
+            add_offense(
+              node,
+              message: "Please do not use class_eval to augment behavior onto a class. " \
+                       "Instead, define the method you want to use in the class definition.",
+            )
           end
         end
       end

--- a/lib/rubocop/cop/gusto/no_rescue_error_message_checking.rb
+++ b/lib/rubocop/cop/gusto/no_rescue_error_message_checking.rb
@@ -3,11 +3,14 @@
 module RuboCop
   module Cop
     module Gusto
-      # Checks for the presence of error message checking within rescue blocks.
+      # Checks for conditional logic inside `rescue` blocks that inspects
+      # the exception's message string (via `match?`, `include?`, or `==`).
+      # This is brittle: message strings are implementation details that can
+      # change between library versions, and they often vary between database
+      # adapters or other runtime environments. Rescue a specific exception
+      # class instead.
       #
-      # This is brittle and can break easily.
-      #
-      # NOTE: We submitted this upstream here: https://github.com/rubocop/rubocop/pull/13352
+      # @see https://github.com/rubocop/rubocop/pull/13352
       #
       # @example
       #
@@ -38,7 +41,7 @@ module RuboCop
       #
       class NoRescueErrorMessageChecking < Base
         MSG = "Avoid checking error message while handling exceptions. This is brittle and can break easily."
-        METHODS_TO_CHECK = %i(match? include? ==).to_set.freeze
+        METHODS_TO_CHECK = %i[match? include? ==].to_set.freeze
 
         def on_rescue(node)
           node.resbody_branches.last.each_descendant(:if, :unless) do |condition_node|
@@ -46,9 +49,7 @@ module RuboCop
           end
         end
 
-        private
-
-        def message_check?(condition_node)
+        private def message_check?(condition_node)
           return unless condition_node.condition.send_type?
           return unless condition_node.condition.receiver
           return unless METHODS_TO_CHECK.include?(condition_node.condition.method_name)

--- a/lib/rubocop/cop/gusto/no_send.rb
+++ b/lib/rubocop/cop/gusto/no_send.rb
@@ -15,7 +15,7 @@ module RuboCop
       #
       class NoSend < Base
         MSG = "Do not call a private method via `__send__`."
-        RESTRICT_ON_SEND = %i(__send__).freeze
+        RESTRICT_ON_SEND = %i[__send__].freeze
 
         # @!method invoke_private_method_send?(node)
         def_node_matcher :invoke_private_method_send?, <<~PATTERN

--- a/lib/rubocop/cop/gusto/paperclip_or_attachable.rb
+++ b/lib/rubocop/cop/gusto/paperclip_or_attachable.rb
@@ -4,9 +4,36 @@
 module RuboCop
   module Cop
     module Gusto
+      # Checks for usage of the deprecated Paperclip macros
+      # (`has_attached_file`) and the internal Attachable macros
+      # (`has_pdf_attachment`, `has_attachment`). Paperclip is no longer
+      # maintained and has known security vulnerabilities. New file attachment
+      # functionality should use ActiveStorage, which ships with Rails.
+      #
+      # @example
+      #   # bad
+      #   class User < ApplicationRecord
+      #     has_attached_file :avatar, styles: { thumb: '100x100>' }
+      #   end
+      #
+      #   # bad
+      #   class Document < ApplicationRecord
+      #     has_pdf_attachment :file
+      #   end
+      #
+      #   # good
+      #   class User < ApplicationRecord
+      #     has_one_attached :avatar
+      #   end
+      #
+      #   # good
+      #   class Document < ApplicationRecord
+      #     has_one_attached :file
+      #   end
+      #
       class PaperclipOrAttachable < Base
         MSG = "No more new paperclip or Attachable are allowed. New attachments should use ActiveStorage instead"
-        RESTRICT_ON_SEND = %i(has_attached_file has_pdf_attachment has_attachment).freeze
+        RESTRICT_ON_SEND = %i[has_attached_file has_pdf_attachment has_attachment].freeze
 
         def on_send(node)
           add_offense(node)

--- a/lib/rubocop/cop/gusto/perform_class_method.rb
+++ b/lib/rubocop/cop/gusto/perform_class_method.rb
@@ -27,7 +27,7 @@ module RuboCop
       #
       class PerformClassMethod < Base
         MSG = "Class-level `perform` method is being defined. Did you mean to use an instance method?"
-        WORKER_FALLBACK = %w(Sidekiq::Worker).freeze
+        WORKER_FALLBACK = %w[Sidekiq::Worker].freeze
         WORKER_MODULES = "WorkerModules"
 
         # @!method worker_module_include?(node)
@@ -44,9 +44,7 @@ module RuboCop
         end
         alias_method :on_defs, :on_def
 
-        private
-
-        def perform_class_method_type(node)
+        private def perform_class_method_type(node)
           if node.receiver&.self_type?
             :self
           elsif node.parent.sclass_type?
@@ -54,7 +52,7 @@ module RuboCop
           end
         end
 
-        def is_sidekiq_worker?(search_node, method_type)
+        private def is_sidekiq_worker?(search_node, method_type)
           search_node = search_node.parent if method_type == :sclass
           search_node.parent.each_child_node.any? do |sibling|
             worker_module_include?(sibling) &&
@@ -62,7 +60,7 @@ module RuboCop
           end
         end
 
-        def worker_modules
+        private def worker_modules
           @worker_modules ||= cop_config.fetch(WORKER_MODULES, WORKER_FALLBACK)
         end
       end

--- a/lib/rubocop/cop/gusto/polymorphic_type_validation.rb
+++ b/lib/rubocop/cop/gusto/polymorphic_type_validation.rb
@@ -1,13 +1,55 @@
 # frozen_string_literal: true
 
-# This cop enforces that polymorphic relations have a corresponding validation
-# for their type field with an inclusion validation. This is required in order for Tapioca
-# to generate correct Sorbet types
 module RuboCop
   module Cop
     module Gusto
+      # Checks that every polymorphic `belongs_to` has a corresponding type
+      # validation using `validates … inclusion: { in: … }` or the
+      # `polymorphic_methods_for` helper. Without this validation Tapioca
+      # (Sorbet's RBI generator) cannot determine which concrete types a
+      # polymorphic association may hold, producing overly-wide or incorrect
+      # type signatures.
+      #
+      # Using `allow_blank: true` on the type validation is also flagged
+      # because it makes the type field optional, which breaks Sorbet's
+      # assumption that the association is always typed.
+      #
+      # @example
+      #   # bad — no type validation
+      #   class Contract < ApplicationRecord
+      #     belongs_to :subscriber, polymorphic: true
+      #   end
+      #
+      #   # bad — allow_blank breaks Sorbet type inference
+      #   class Contract < ApplicationRecord
+      #     VALID_TYPES = [Employee.polymorphic_name].freeze
+      #     belongs_to :subscriber, polymorphic: true
+      #     validates :subscriber_type, inclusion: { in: VALID_TYPES },
+      #                                 allow_blank: true
+      #   end
+      #
+      #   # good — explicit inclusion validation
+      #   class Contract < ApplicationRecord
+      #     VALID_TYPES = T.let(
+      #       [Employee.polymorphic_name, Contractor.polymorphic_name].freeze,
+      #       T::Array[String]
+      #     )
+      #     belongs_to :subscriber, polymorphic: true
+      #     validates :subscriber_type, inclusion: { in: VALID_TYPES }
+      #   end
+      #
+      #   # good — using the polymorphic_methods_for helper
+      #   class Contract < ApplicationRecord
+      #     VALID_TYPES = T.let(
+      #       [Employee.polymorphic_name, Contractor.polymorphic_name].freeze,
+      #       T::Array[String]
+      #     )
+      #     belongs_to :subscriber, polymorphic: true
+      #     polymorphic_methods_for :subscriber, VALID_TYPES
+      #   end
+      #
       class PolymorphicTypeValidation < Base
-        RESTRICT_ON_SEND = %i(belongs_to validates polymorphic_methods_for).freeze
+        RESTRICT_ON_SEND = %i[belongs_to validates polymorphic_methods_for].freeze
 
         MSG = <<~MESSAGE
           Polymorphic relations must validate their corresponding type field with "validates .. inclusion: { in: .. }", or using polymorphic_methods_for
@@ -60,7 +102,16 @@ module RuboCop
 
           relation_name = node.first_argument.value
           type_field = :"#{relation_name}_type"
+          has_validation, has_allow_blank = check_validations(node, type_field, relation_name)
 
+          if has_allow_blank
+            add_offense(node, message: ALLOW_BLANK_MSG)
+          elsif !has_validation
+            add_offense(node)
+          end
+        end
+
+        private def check_validations(node, type_field, relation_name)
           # Look for either a validation of the type field or polymorphic_methods_for
           has_validation = false
           has_allow_blank = false
@@ -77,11 +128,7 @@ module RuboCop
             end
           end
 
-          if has_allow_blank
-            add_offense(node, message: ALLOW_BLANK_MSG)
-          elsif !has_validation
-            add_offense(node)
-          end
+          [has_validation, has_allow_blank]
         end
       end
     end

--- a/lib/rubocop/cop/gusto/rabl_extends.rb
+++ b/lib/rubocop/cop/gusto/rabl_extends.rb
@@ -21,7 +21,7 @@ module RuboCop
       class RablExtends < Base
         MSG = "Avoid using Rabl extends as it has poor caching performance. Inline your JSON instead."
         RABL_EXTENSION = ".rabl"
-        RESTRICT_ON_SEND = %i(extends).freeze
+        RESTRICT_ON_SEND = %i[extends].freeze
 
         # @!method rabl_extends?(node)
         def_node_matcher :rabl_extends?, <<~PATTERN

--- a/lib/rubocop/cop/gusto/rails_env.rb
+++ b/lib/rubocop/cop/gusto/rails_env.rb
@@ -32,7 +32,7 @@ module RuboCop
         # (Rails.env.methods - Object.instance_methods).select { |m| m.to_s.end_with?('?') }
         # and then removing the environment specific methods like development?, test?, production?
         ALLOWED_LIST = Set.new(
-          %i(
+          %i[
             unicode_normalized?
             exclude?
             empty?
@@ -49,10 +49,10 @@ module RuboCop
             ascii_only?
             between?
             local?
-          )
+          ],
         ).freeze
         MSG = "Use Feature Flags or config instead of `Rails.env`."
-        RESTRICT_ON_SEND = %i(env).freeze
+        RESTRICT_ON_SEND = %i[env].freeze
 
         # @!method prohibited_rails_env?(node)
         def_node_matcher :prohibited_rails_env?, <<~PATTERN
@@ -66,9 +66,7 @@ module RuboCop
           add_offense(node.parent) if prohibited_rails_env?(node.parent)
         end
 
-        private
-
-        def prohibited_predicate?(name)
+        private def prohibited_predicate?(name)
           name.to_s.end_with?("?") && !ALLOWED_LIST.include?(name)
         end
       end

--- a/lib/rubocop/cop/gusto/rake_constants.rb
+++ b/lib/rubocop/cop/gusto/rake_constants.rb
@@ -28,7 +28,8 @@ module RuboCop
       #   end
       #
       class RakeConstants < Base
-        MSG = "Do not define a constant in rake file, because they are sometimes `load`ed, instead of `require`d which can lead to warnings about redefining constants"
+        MSG = "Do not define a constant in rake file, because they are sometimes " \
+              "`load`ed, instead of `require`d which can lead to warnings about redefining constants"
 
         # @!method task_or_namespace?(node)
         def_node_matcher :task_or_namespace?, <<-PATTERN
@@ -57,9 +58,7 @@ module RuboCop
           add_offense(node)
         end
 
-        private
-
-        def in_task_or_namespace?(node)
+        private def in_task_or_namespace?(node)
           node.each_ancestor(:block).any? { |ancestor| task_or_namespace?(ancestor) }
         end
       end

--- a/lib/rubocop/cop/gusto/regexp_bypass.rb
+++ b/lib/rubocop/cop/gusto/regexp_bypass.rb
@@ -52,37 +52,33 @@ module RuboCop
           return unless captureless_source.start_with?(PROHIBITED_ANCHOR) || captureless_source.end_with?(PROHIBITED_END_ANCHOR)
 
           add_offense(first_child) do |corrector|
-            source_buffer = first_child.source_range.source_buffer
-            actual_source = first_child.source
-
-            if captureless_source.start_with?(PROHIBITED_ANCHOR)
-              # Find the position of ^ within the source, accounting for parentheses
-              caret_pos = actual_source.index(PROHIBITED_ANCHOR)
-              start_pos = first_child.source_range.begin_pos + caret_pos
-              corrector.replace(
-                Parser::Source::Range.new(
-                  source_buffer,
-                  start_pos,
-                  start_pos + 1
-                ),
-                '\A'
-              )
-            end
-
-            if captureless_source.end_with?(PROHIBITED_END_ANCHOR)
-              # Find the position of $ within the source, accounting for parentheses
-              dollar_pos = actual_source.rindex(PROHIBITED_END_ANCHOR)
-              end_pos = first_child.source_range.begin_pos + dollar_pos + 1
-              corrector.replace(
-                Parser::Source::Range.new(
-                  source_buffer,
-                  end_pos - 1,
-                  end_pos
-                ),
-                '\z'
-              )
-            end
+            correct_anchors(corrector, first_child, captureless_source)
           end
+        end
+
+        private def correct_anchors(corrector, node, captureless_source)
+          source_buffer = node.source_range.source_buffer
+          actual_source = node.source
+
+          if captureless_source.start_with?(PROHIBITED_ANCHOR)
+            # Find the position of ^ within the source, accounting for parentheses
+            caret_pos = actual_source.index(PROHIBITED_ANCHOR)
+            start_pos = node.source_range.begin_pos + caret_pos
+            corrector.replace(
+              Parser::Source::Range.new(source_buffer, start_pos, start_pos + 1),
+              '\A',
+            )
+          end
+
+          return unless captureless_source.end_with?(PROHIBITED_END_ANCHOR)
+
+          # Find the position of $ within the source, accounting for parentheses
+          dollar_pos = actual_source.rindex(PROHIBITED_END_ANCHOR)
+          end_pos = node.source_range.begin_pos + dollar_pos + 1
+          corrector.replace(
+            Parser::Source::Range.new(source_buffer, end_pos - 1, end_pos),
+            '\z',
+          )
         end
       end
     end

--- a/lib/rubocop/cop/gusto/rspec_date_time_mock.rb
+++ b/lib/rubocop/cop/gusto/rspec_date_time_mock.rb
@@ -28,10 +28,10 @@ module RuboCop
         CLASSES = Set[
           :Date,
           :Time,
-          :DateTime
+          :DateTime,
         ].freeze
         MSG = "Don't mock #{CLASSES.join('/')} directly. Use Rails Testing Time Helpers (eg `freeze_time` and `travel_to`) instead.".freeze
-        RESTRICT_ON_SEND = %i(to).freeze
+        RESTRICT_ON_SEND = %i[to].freeze
 
         # @!method and_call_original?(node)
         def_node_search :and_call_original?, <<~PATTERN
@@ -67,11 +67,9 @@ module RuboCop
           end
         end
 
-        private
-
         # Returns true if the given node is a const or a call chain whose root receiver
         # is one of the protected time classes (Date/Time/DateTime)
-        def rooted_in_time_class?(node)
+        private def rooted_in_time_class?(node)
           return false if node.nil?
 
           current = node
@@ -89,7 +87,7 @@ module RuboCop
           is_root_level && CLASSES.include?(current.short_name)
         end
 
-        def and_call_original_in_chain?(node)
+        private def and_call_original_in_chain?(node)
           return false if node.nil?
           return false unless node.send_type?
 

--- a/lib/rubocop/cop/gusto/sidekiq_params.rb
+++ b/lib/rubocop/cop/gusto/sidekiq_params.rb
@@ -3,6 +3,19 @@
 module RuboCop
   module Cop
     module Gusto
+      # Checks for keyword arguments in Sidekiq `perform` methods. Sidekiq
+      # serializes job arguments to JSON, which does not preserve the
+      # positional/keyword distinction — keyword arguments are unsupported and
+      # will be silently lost when the job is dequeued.
+      #
+      # @example
+      #   # bad
+      #   def perform(user_id:, action:)
+      #   end
+      #
+      #   # good
+      #   def perform(user_id, action)
+      #   end
       class SidekiqParams < Base
         MSG = "Sidekiq perform methods cannot take keyword arguments"
 

--- a/lib/rubocop/cop/gusto/use_paint_not_colorize.rb
+++ b/lib/rubocop/cop/gusto/use_paint_not_colorize.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         # Common terminal color methods that should be prevented
         COLOR_METHODS = Set.new(
-          %i(
+          %i[
             black
             red
             green
@@ -83,19 +83,19 @@ module RuboCop
             swap
             hide
             uncolorize
-          )
+          ],
         ).freeze
 
         # Style modifiers that are applied as additional options in Paint
         STYLE_MODIFIERS = Set.new(
-          %i(
+          %i[
             bold
             italic
             underline
             blink
             swap
             hide
-          )
+          ],
         ).freeze
 
         MSG = "Use Paint instead of colorize for terminal colors."
@@ -117,23 +117,21 @@ module RuboCop
           add_offense(node) # no autocorrection for safe navigation due to chained calls
         end
 
-        private
-
-        def string_or_colorized_receiver?(node)
+        private def string_or_colorized_receiver?(node)
           string_receiver?(node) || colorized_string?(node)
         end
 
-        def string_receiver?(node)
+        private def string_receiver?(node)
           node.type?(:str, :dstr) || node.variable?
         end
 
-        def colorized_string?(node)
+        private def colorized_string?(node)
           node.send_type? &&
             node.receiver &&
             string_or_colorized_receiver?(node.receiver)
         end
 
-        def correction(node)
+        private def correction(node)
           # Find the original string and all color/style operations in the chain
           original_string, color_ops = extract_string_and_operations(node)
 
@@ -196,7 +194,7 @@ module RuboCop
           build_paint_call(original_string, foreground, background, styles)
         end
 
-        def extract_string_and_operations(node)
+        private def extract_string_and_operations(node)
           operations = []
           current = node
 
@@ -206,7 +204,7 @@ module RuboCop
               {
                 method: current.method_name,
                 args: current.arguments,
-              }
+              },
             )
 
             current = current.receiver
@@ -216,7 +214,7 @@ module RuboCop
           [current, operations]
         end
 
-        def build_paint_call(string_node, foreground, background, styles)
+        private def build_paint_call(string_node, foreground, background, styles)
           # Use string_content for string nodes, or source for variables and other expressions
           string_expr = string_node.source
 

--- a/lib/rubocop/cop/gusto/vcr_recordings.rb
+++ b/lib/rubocop/cop/gusto/vcr_recordings.rb
@@ -34,13 +34,11 @@ module RuboCop
           end
         end
 
-        private
-
-        def vcr_setting?(node)
+        private def vcr_setting?(node)
           node.parent.parent.source.include?("vcr")
         end
 
-        def recording_enabled?(option, value)
+        private def recording_enabled?(option, value)
           option == :record && value != :none
         end
       end

--- a/lib/rubocop/cop/internal_affairs/assignment_first.rb
+++ b/lib/rubocop/cop/internal_affairs/assignment_first.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   end
       #
       class AssignmentFirst < Base
-        HOOKS = %i(
+        HOOKS = %i[
           on_def
           on_defs
           on_send
@@ -37,8 +37,8 @@ module RuboCop
           after_csend
           after_class
           after_module
-        ).to_set.freeze
-        MSG = "Avoid placing an assignment as the first action in `%{hook}`."
+        ].to_set.freeze
+        MSG = "Avoid placing an assignment as the first action in `%<hook>s`."
 
         def on_def(node)
           return unless HOOKS.include?(node.method_name)

--- a/lib/rubocop/cop/rack/lowercase_header_keys.rb
+++ b/lib/rubocop/cop/rack/lowercase_header_keys.rb
@@ -27,7 +27,7 @@ module RuboCop
       class LowercaseHeaderKeys < Base
         extend AutoCorrector
 
-        MSG = "HTTP response header keys should be lowercase. Use `%{downcased}` instead of `%{original}`."
+        MSG = "HTTP response header keys should be lowercase. Use `%<downcased>s` instead of `%<original>s`."
         RESTRICT_ON_SEND = %i([]= [] set_header get_header delete_header has_header?).freeze
 
         # @!method response_header_method?(node)
@@ -68,9 +68,7 @@ module RuboCop
           check_key(key_node)
         end
 
-        private
-
-        def check_bracket_access(node)
+        private def check_bracket_access(node)
           receiver = node.receiver
           return unless receiver.send_type? && response_headers_receiver?(receiver)
 
@@ -80,12 +78,12 @@ module RuboCop
           check_key(key_node)
         end
 
-        def check_header_method(node)
+        private def check_header_method(node)
           key_node = node.first_argument
           check_key(key_node)
         end
 
-        def check_key(key_node)
+        private def check_key(key_node)
           key_value = key_node.value
           return if key_value.empty?
           return if key_value == key_value.downcase
@@ -99,7 +97,7 @@ module RuboCop
         #   self.headers
         # Does NOT match:
         #   conn.headers, request.headers, client.headers, etc.
-        def response_headers_receiver?(receiver)
+        private def response_headers_receiver?(receiver)
           return false unless receiver.method?(:headers)
 
           inner = receiver.receiver
@@ -120,11 +118,11 @@ module RuboCop
           end
         end
 
-        def add_offense_for_header(node, key_value)
+        private def add_offense_for_header(node, key_value)
           downcased = key_value.downcase
-          message = format(MSG, downcased: downcased, original: key_value)
+          message = format(MSG, downcased:, original: key_value)
 
-          add_offense(node, message: message) do |corrector|
+          add_offense(node, message:) do |corrector|
             corrector.replace(node, "'#{downcased}'")
           end
         end

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -33,9 +33,7 @@ module RuboCop
           (block (send nil? :sig) _ _)
         PATTERN
 
-        private
-
-        def check_let_declarations(body)
+        private def check_let_declarations(body)
           children = body.each_child_node.to_a
           units = build_let_units(children)
           return if units.empty?
@@ -49,7 +47,7 @@ module RuboCop
             else
               add_offense(unit.let) do |corrector|
                 ::RuboCop::RSpec::Corrector::MoveNode.new(
-                  unit.let, corrector, processed_source
+                  unit.let, corrector, processed_source,
                 ).move_after(reference_unit.let)
               end
             end
@@ -57,7 +55,7 @@ module RuboCop
           end
         end
 
-        def build_let_units(children)
+        private def build_let_units(children)
           children.each_with_index.with_object([]) do |(node, idx), units|
             next unless let?(node)
 

--- a/lib/rubocop/gusto/cli.rb
+++ b/lib/rubocop/gusto/cli.rb
@@ -6,6 +6,7 @@ require "rubocop/gusto/init"
 
 module RuboCop
   module Gusto
+    # Command-line interface for rubocop-gusto. Provides `init` and `sort` commands.
     class Cli < Thor
       register(Init, "init", "init", "Initialize rubocop-gusto and update .rubocop.yml")
 

--- a/lib/rubocop/gusto/config_yml.rb
+++ b/lib/rubocop/gusto/config_yml.rb
@@ -11,9 +11,9 @@ module RuboCop
     # and YAML.dump. Simple, we want to preserve the comments.
     class ConfigYml
       COMMENT_REGEX = /\A\s*#.*\z/
-      COP_HEADER_REGEX = /\A[A-Z0-9][A-Za-z0-9\/:]+:(\s*#.*)?\z/
-      KEY_REGEX = /\A\w[\w\/]+:(\s*#.*)?\z/i # case insensitive
-      PREAMBLE_KEYS = %w(inherit_mode inherit_gem inherit_from plugins require).freeze
+      COP_HEADER_REGEX = %r{\A[A-Z0-9][A-Za-z0-9/:]+:(\s*#.*)?\z}
+      KEY_REGEX = %r{\A\w[\w/]+:(\s*#.*)?\z}i # case insensitive
+      PREAMBLE_KEYS = %w[inherit_mode inherit_gem inherit_from plugins require].freeze
       INDENT_REGEX = /\A(  |- )/
 
       # @param [String] file_path the path to the .rubocop.yml file
@@ -105,10 +105,8 @@ module RuboCop
         File.write(file_path, to_s)
       end
 
-      private
-
       # Return the name of a chunk by finding the root key
-      def chunk_name(chunk)
+      private def chunk_name(chunk)
         # Try to find a line that exactly matches KEY_REGEX
         # Use rstrip, not strip, to preserve indentation
         name_line = chunk.find { |line| line.rstrip.match?(KEY_REGEX) }
@@ -117,44 +115,41 @@ module RuboCop
         else
           # Try to find a key with value on the same line (e.g., "inherit_from: .rubocop_todo.yml")
           first_line = chunk.find { |line| !line.strip.empty? && !line.strip.start_with?("#") }
-          if first_line&.include?(":")
-            first_line.split(":").first.strip
-          end
+          first_line.split(":").first.strip if first_line&.include?(":")
         end
       end
 
       # Splits the lines into blocks whenever we drop from indented to unindented
-      def chunk_blocks(lines)
+      private def chunk_blocks(lines)
         # slice whenever we drop from indented to unindented line
         # or when we encounter a new top-level key after blank line(s)
-        chunks = lines.slice_when do |prev, line|
-          if prev.strip.empty?
-            # split when going from blank to non-indented non-blank
-            !line.match?(INDENT_REGEX) && !line.strip.empty?
-          elsif prev.match?(INDENT_REGEX)
-            # split when going from indented to non-blank unindented
-            !line.match?(INDENT_REGEX) && !line.strip.empty?
-          else
-            # prev is non-indented, split on blank lines too
-            line.strip.empty?
-          end
-        end
+        chunks = lines.slice_when { |prev, line| split_chunk?(prev, line) }
 
         # Process each chunk to remove leading newlines and add 1 trailing newline
         chunks.filter_map do |chunk|
           # Remove leading and trailing empty lines
-          until chunk.empty? || !chunk.first.strip.empty?
-            chunk.shift
-          end
-          until chunk.empty? || !chunk.last.strip.empty?
-            chunk.pop
-          end
+          chunk.shift until chunk.empty? || !chunk.first.strip.empty?
+          chunk.pop until chunk.empty? || !chunk.last.strip.empty?
 
           # Skip empty chunks
           next if chunk.empty?
 
           # Ensure each chunk ends with a blank newline
           chunk << "\n"
+        end
+      end
+
+      # Returns true when a chunk boundary should be inserted between prev and line.
+      private def split_chunk?(prev, line)
+        if prev.strip.empty?
+          # split when going from blank to non-indented non-blank
+          !line.match?(INDENT_REGEX) && !line.strip.empty?
+        elsif prev.match?(INDENT_REGEX)
+          # split when going from indented to non-blank unindented
+          !line.match?(INDENT_REGEX) && !line.strip.empty?
+        else
+          # prev is non-indented; split on blank lines too
+          line.strip.empty?
         end
       end
     end

--- a/lib/rubocop/gusto/init.rb
+++ b/lib/rubocop/gusto/init.rb
@@ -6,10 +6,11 @@ require "rubocop/gusto/config_yml"
 
 module RuboCop
   module Gusto
+    # Thor generator that adds rubocop-gusto to a project's .rubocop.yml.
     class Init < Thor::Group
       include Thor::Actions
 
-      PLUGINS = %w(rubocop-gusto rubocop-rspec rubocop-performance rubocop-rake rubocop-rails).freeze
+      PLUGINS = %w[rubocop-gusto rubocop-rspec rubocop-performance rubocop-rake rubocop-rails].freeze
 
       class_option :rubocop_yml, type: :string, default: ".rubocop.yml"
 
@@ -39,7 +40,7 @@ module RuboCop
           config.add_plugin(PLUGINS)
         else
           config.add_inherit_gem("rubocop-gusto", "config/default.yml")
-          config.add_plugin(PLUGINS - %w(rubocop-rails))
+          config.add_plugin(PLUGINS - %w[rubocop-rails])
         end
 
         config.sort!
@@ -49,9 +50,7 @@ module RuboCop
         create_file(".rubocop_todo.yml", skip: true)
       end
 
-      private
-
-      def rails?
+      private def rails?
         File.exist?("config/application.rb")
       end
     end

--- a/lib/rubocop/gusto/move_node_patch.rb
+++ b/lib/rubocop/gusto/move_node_patch.rb
@@ -4,6 +4,7 @@ require "rubocop/rspec/corrector/move_node"
 
 module RuboCop
   module RSpec
+    # Namespace for rubocop-rspec autocorrect helpers patched by this gem.
     module Corrector
       # Patches `MoveNode` to treat Sorbet `sig { ... }` blocks as part of the
       # `let`/`subject`/hook they precede.
@@ -37,20 +38,18 @@ module RuboCop
           super(sig || other)
         end
 
-        private
-
-        def node_range(node)
+        private def node_range(node)
           sig = preceding_sig_block(node)
           return super unless sig
 
           ::Parser::Source::Range.new(
             buffer,
             begin_pos_with_comment(sig).begin_pos,
-            end_line_position(node).end_pos
+            end_line_position(node).end_pos,
           )
         end
 
-        def preceding_sig_block(node)
+        private def preceding_sig_block(node)
           prev = node.left_sibling
           prev if sig_block?(prev)
         end

--- a/lib/rubocop/gusto/plugin.rb
+++ b/lib/rubocop/gusto/plugin.rb
@@ -11,7 +11,7 @@ module RuboCop
           name: "rubocop-gusto",
           version: RuboCop::Gusto::VERSION,
           homepage: "https://github.com/Gusto/rubocop-gusto",
-          description: "A collection of Gusto's standard RuboCop cops and rules."
+          description: "A collection of Gusto's standard RuboCop cops and rules.",
         )
       end
 

--- a/prompts/update-rubocop-config.md
+++ b/prompts/update-rubocop-config.md
@@ -1,0 +1,217 @@
+# Update RuboCop configuration
+
+Review and update the RuboCop cop configurations in config/default-next.yml and
+config/rails-next.yml. These configs are for new Ruby services and are intentionally
+separate from config/default.yml and config/rails.yml, which cover existing
+projects and should not be modified.
+
+## Files
+
+- config/default-next.yml — applies to all Ruby projects
+- config/rails-next.yml  — applies to Rails projects (loaded alongside default-next.yml)
+
+## Priorities (highest to lowest)
+
+1. Sorbet compatibility. Any cop that produces output incompatible with Sorbet's
+   static analysis must be disabled, regardless of other benefits. This is a hard
+   constraint. When in doubt, check
+   <https://github.com/sorbet/sorbet/issues>.
+
+2. Correctness and safety. Prefer configurations that prevent bugs, data loss,
+   or security vulnerabilities over those that are purely stylistic. Lint cops
+   that catch real bugs should be elevated to Severity: error.
+
+3. Reviewability and diff quality. Smaller, more focused diffs are preferable.
+   Favor cops that reduce the number of ways to write functionally equivalent
+   code (e.g. trailing commas on multiline literals, fixed indentation over
+   alignment-based indentation).
+
+4. Consistency for coding agents. Agents are the primary authors and readers.
+   Favor configurations that result in agents generating similar code across
+   similar contexts — consistent indentation, structure, and idiom reduce the
+   surface area agents must reason about.
+
+5. Idiomatic modern Ruby. Follow what the Rails project, RuboCop's own style
+   guide, and widely-adopted style guides (Standard, Shopify) agree on. Prefer
+   modern syntax over legacy alternatives when the ecosystem has converged (e.g.
+   symbol-key hashes over hash rockets, `->` lambdas, `alias_method` over
+   `alias`). Do not standardize on an older form merely because it reduces
+   variation.
+
+6. Performance. Prefer configurations appropriate for high-scale web applications.
+   Enable performance cops that eliminate unnecessary allocations or inefficient
+   patterns.
+
+The cost of resolving a linter violation is low — most are autocorrectable
+before a CI run begins. Do not disable or relax cops to avoid fixing existing
+violations.
+
+The cost of an additional CI run, however, is high. In monolith repositories a
+single change can select a large test suite, making each failed CI run expensive
+in both time and engineering attention. Configurations that prevent agents from
+producing code that will fail CI are therefore especially valuable — more so
+than configurations that merely enforce style. When choosing between two
+otherwise equivalent configurations, prefer the one that makes a class of
+runtime or test-time error impossible to introduce in the first place.
+
+For example, `Style/AccessModifierDeclarations: EnforcedStyle: inline` requires
+access modifiers to appear on the same line as the method definition
+(`private def foo`). This makes it structurally impossible for an agent to
+place a public method inside a `private` group — a mistake that compiles and
+passes static analysis but causes test failures at runtime when callers outside
+the class attempt to invoke the method.
+
+## Process
+
+A complete review considers three dimensions for every cop in every plugin:
+whether it is enabled, whether its non-boolean parameters are set correctly, and
+whether it has any mode flags (`AllowedMethods`, `AllowedPatterns`,
+`CheckForMethodsWithNoSideEffects`, `IncludeActiveSupportAliases`, etc.) that
+change what the cop catches. Enabling a cop with poor parameter choices can be
+worse than not enabling it at all.
+
+### Step 1 — Read the full default configuration
+
+For each cop in each plugin's `config/default.yml`, extract **all** configurable
+keys, not just `Enabled`. Typical parameters to examine:
+
+- `EnforcedStyle` and `SupportedStyles` — which style is the default and whether
+  the alternatives are better for Sorbet-typed, high-scale Rails code
+- `Max` / `Min` — numeric limits; see the **Setting numeric limits** section
+- `CheckFor…` / `Include…` / `Allow…` flags — boolean mode switches that
+  expand or restrict what the cop catches (e.g.
+  `CheckForMethodsWithNoSideEffects`, `IncludeActiveSupportAliases`,
+  `AllowUnusedKeywordArguments`)
+- `AllowedMethods` / `AllowedPatterns` — lists that suppress the cop for
+  specific call sites; ensure these are not inadvertently too broad
+- `Safe` / `SafeAutoCorrect` — whether the autocorrect changes semantics; flag
+  any unsafe autocorrects that could silently alter behavior
+
+### Step 2 — Evaluate each parameter against the priorities
+
+For every non-default parameter value that could be set:
+
+1. **Does the default parameter value conflict with Sorbet?** Some parameters
+   trigger autocorrects that break Sorbet sigs (e.g. removing a `&blk` param
+   that a sig references). Override to preserve Sorbet compatibility.
+
+2. **Does a non-default value catch more real bugs?** Mode flags like
+   `CheckForMethodsWithNoSideEffects: true` extend a cop's reach to cover
+   additional error classes. If the extended coverage catches genuine mistakes
+   without significant false-positive risk, enable it.
+
+3. **Does the parameter affect consistency or diff quality?** Style parameters
+   like `EnforcedShorthandSyntax: either_consistent` prevent mixed patterns
+   within a single construct, reducing variation without forcing a global choice.
+
+4. **Does the parameter need to account for Rails or ActiveSupport extensions?**
+   Several cops have flags like `IncludeActiveSupportAliases` that are `false`
+   by default because Active Support is not universally present. In rails-next.yml,
+   enable these flags when the ActiveSupport method is a better candidate for
+   enforcement than the stdlib equivalent.
+
+5. **Do not add a parameter entry that matches the default.** Only configure
+   parameters that deviate from the upstream default, for the same reason that
+   redundant `Enabled: true` entries are omitted.
+
+### Step 3 — Placement, ordering, and comments
+
+1. Verify which file the cop belongs in: default-next.yml for all Ruby projects,
+   rails-next.yml for Rails-specific cops.
+
+2. Maintain alphabetical ordering within each file.
+
+3. Include a comment for every entry explaining:
+   - Why the default was changed, or why a disabled-by-default cop is enabled
+   - Why a non-default parameter value was chosen
+   - Any relevant links (upstream issues, style guide references, incident reports)
+   - **Do not cite the legacy config as a justification.** "Matches the legacy
+     config" is not a reason to disable or relax a cop. Every entry must stand
+     on its own merits within the priority framework.
+
+## Setting numeric limits
+
+Many cops enforce a numeric ceiling — maximum method length, maximum number of
+expectations per example, maximum ABC score, and so on. RuboCop's upstream
+defaults for these limits are calibrated for general Ruby programs, not for
+high-scale web applications. Production web services routinely involve concerns
+that have no analog in the programs rubocop's authors had in mind: network
+failure handling, database transaction management, multi-step validation logic,
+authentication and authorization layers, serialization across API boundaries,
+and background job orchestration. Each of these concerns legitimately adds
+lines, branches, and complexity without indicating that code is poorly designed.
+
+When evaluating a numeric limit, do not accept the upstream default uncritically.
+Instead, reason about what the limit means for code of this kind:
+
+- **Is the upstream default calibrated for production web services?** If the
+  default would flag a large fraction of ordinary, well-written application
+  code, it is not functioning as a signal — it is functioning as noise. A limit
+  that fires constantly requires agents to burn cycles reorganizing code rather
+  than solving the assigned problem.
+
+- **What does a genuine violation look like in this context?** The limit should
+  separate code that is incidentally complex (handling real requirements) from
+  code that is structurally complex (doing too many things, missing
+  abstractions, or resisting decomposition). The former is acceptable; the
+  latter is what the cop should catch.
+
+- **Is the limit consistent with what we already accept?** Examine the existing
+  entries in config/default-next.yml for the same category of cop. If the Metrics
+  limits are set well above the rubocop defaults to reflect production
+  realities, apply the same reasoning to RSpec limits, line-length limits, and
+  any other numeric threshold. The calibration philosophy should be uniform.
+
+In practice, limits for high-scale web application code are often materially
+higher than rubocop's defaults — sometimes two to five times higher. This is
+not a relaxation of quality standards; it is an acknowledgment that the default
+was written for a different class of program. The goal is a limit that fires
+on code that genuinely needs attention, not on code that is merely longer than
+a script or utility gem would be.
+
+## New cops and pending cops
+
+The shared config sets `NewCops: disable` in `AllCops`. This means cops that
+are newly added to rubocop or its plugins default to off. The reason is not
+to give the team time to evaluate them — that is unlikely to happen organically.
+The reason is to allow the broader rubocop community to surface issues, report
+false positives, and refine the cop's behavior before we adopt it. Pending cops
+are experimental by design; the community feedback loop is how they get
+stabilized. Do not change this setting.
+
+Pending cops (those marked `Enabled: pending` in the upstream gem) are
+**not** automatically enabled by `NewCops: disable`. During a config review,
+consider each pending cop explicitly: read its description, evaluate it against
+the priority framework, and add an entry to enable it if it is sufficiently
+mature and useful. If you enable a pending cop, note in the comment that it is
+pending upstream.
+
+## Stability of existing configuration
+
+Once a cop is configured — enabled, disabled, or given specific parameter
+values — that setting should be treated as a deliberate decision. Do not
+revisit or overturn existing settings without strong, concrete evidence that
+the current setting is wrong. Acceptable reasons to change an existing entry:
+
+- A production incident or CI failure that the new setting would make less
+  likely, or that the current setting contributed to.
+- A Sorbet compatibility issue newly discovered or newly documented upstream.
+- Empirical data (e.g. updated percentile measurements from production
+  codebases) that materially changes the numeric calibration.
+- A cop's behavior changed in a new gem version in a way that makes the
+  existing configuration incorrect.
+
+Arguments based on personal preference, aesthetic disagreement, or "this seems
+wrong" without specific evidence do not meet this bar. The cost of changing a
+widely-deployed lint standard is borne by every codebase that inherits it. A
+reconfiguration that touches dozens of services consumes CI cycles and adds
+noise to git history across all of them — churn
+that delivers no product value. Stability in the configuration is itself a
+value.
+
+## Conflict resolution
+
+When the priorities above conflict in a way that is not clearly resolved by their
+ordering — for example, a cop that improves consistency but requires a non-idiomatic
+style, or a performance cop whose autocorrect is unsafe — pause and ask for guidance
+before proceeding.

--- a/rubocop-gusto.gemspec
+++ b/rubocop-gusto.gemspec
@@ -14,12 +14,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.2"
 
-  if spec.respond_to?(:metadata)
-    # spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-    spec.metadata["default_lint_roller_plugin"] = "RuboCop::Gusto::Plugin"
-  else
-    raise("RubyGems 2.0 or newer is required to protect against public gem pushes.")
-  end
+  raise("RubyGems 2.0 or newer is required to protect against public gem pushes.") unless spec.respond_to?(:metadata)
+
+  # spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+  spec.metadata["default_lint_roller_plugin"] = "RuboCop::Gusto::Plugin"
 
   spec.files = Dir["{lib,exe,config}/**/*", "README.md", "CHANGELOG.md", "LICENSE"]
   spec.bindir = "exe"

--- a/spec/rubocop/cop/gusto/polymorphic_type_validation_spec.rb
+++ b/spec/rubocop/cop/gusto/polymorphic_type_validation_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe RuboCop::Cop::Gusto::PolymorphicTypeValidation, :config do
       offenses = inspect_source(source)
       expect(offenses.size).to eq(1)
       expect(offenses.first.message).to include(
-        'Polymorphic relations must validate their corresponding type field with "validates .. inclusion: { in: .. }", or using polymorphic_methods_for'
+        "Polymorphic relations must validate their corresponding type field with " \
+          '"validates .. inclusion: { in: .. }", or using polymorphic_methods_for',
       )
     end
   end
@@ -70,7 +71,8 @@ RSpec.describe RuboCop::Cop::Gusto::PolymorphicTypeValidation, :config do
       offenses = inspect_source(source)
       expect(offenses.size).to eq(1)
       expect(offenses.first.message).to include(
-        'Polymorphic relations must validate their corresponding type field with "validates .. inclusion: { in: .. }", or using polymorphic_methods_for'
+        "Polymorphic relations must validate their corresponding type field with " \
+          '"validates .. inclusion: { in: .. }", or using polymorphic_methods_for',
       )
     end
   end
@@ -81,7 +83,7 @@ RSpec.describe RuboCop::Cop::Gusto::PolymorphicTypeValidation, :config do
         offenses = inspect_source(source)
         expect(offenses.size).to eq(1)
         expect(offenses.first.message).to include(
-          "Polymorphic type validations cannot use allow_blank: true"
+          "Polymorphic type validations cannot use allow_blank: true",
         )
       end
     end

--- a/spec/rubocop/gusto/cli_spec.rb
+++ b/spec/rubocop/gusto/cli_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 require "tempfile"
 require "fileutils"
 
-RSpec.describe "rubocop-gusto CLI" do
+RSpec.describe "rubocop-gusto CLI", type: :integration do
   def run_cli(*command)
     cli_path = File.expand_path("../../../exe/rubocop-gusto", __dir__)
     stdout, status = Open3.capture2e(cli_path, *command)

--- a/spec/rubocop/gusto/config_yml_spec.rb
+++ b/spec/rubocop/gusto/config_yml_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
     it "ensure our template is up to date" do
       template_path = File.expand_path("../../../lib/rubocop/gusto/templates/rubocop.yml", __dir__)
       config = described_class.load_file(template_path)
-      config.add_plugin(%w(rubocop-gusto rubocop-rspec rubocop-performance rubocop-rake))
+      config.add_plugin(%w[rubocop-gusto rubocop-rspec rubocop-performance rubocop-rake])
       config.add_inherit_gem("rubocop-gusto", "config/default.yml")
       config.sort!
       expect(File.readlines(template_path)).to eq(config.lines), "TEMPLATE IS OUT OF DATE.\n*** Run `bundle exec rake update_template` to update it."
@@ -35,17 +35,17 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
 
   describe "#empty?" do
     it "returns false if the file has lines" do
-      expect(described_class.load_file(sorted_path).empty?).to be_falsey
+      expect(described_class.load_file(sorted_path)).not_to be_empty
     end
 
     it "returns true if the file does not exist" do
-      expect(described_class.load_file("nonexistent_file.yml").empty?).to be_truthy
+      expect(described_class.load_file("nonexistent_file.yml")).to be_empty
     end
 
     it "returns true if the file has no lines" do
       Tempfile.create(["rubocop_empty", ".yml"]) do |tmpfile|
         tmpfile.write("")
-        expect(described_class.load_file(tmpfile.path).empty?).to be_truthy
+        expect(described_class.load_file(tmpfile.path)).to be_empty
       end
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
       expect(described_class.new([]).lines).to eq([])
     end
 
-    it "it cleans whitespace" do
+    it "cleans whitespace" do
       config = described_class.new(["\n", "  \n", "\n", "  \n", "# this is an empty file\n", "\n", "\n"])
       expect(config.lines).to eq(["# this is an empty file\n"])
     end
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
         "\n",
       ]
 
-      described_class.new(lines).lines
+      expect(described_class.new(lines).lines).to be_an(Array)
     end
   end
 
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
           Enabled: true
       YAML
 
-      config.add_plugin(%w(rubocop-gusto))
+      config.add_plugin(%w[rubocop-gusto])
       config.sort!
 
       expect(config.to_s).to eq(<<~YAML)
@@ -265,7 +265,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
         plugins:
       YAML
 
-      config.add_plugin(%w(rubocop-gusto))
+      config.add_plugin(%w[rubocop-gusto])
       config.sort!
 
       expect(config.to_s).to eq(<<~YAML)
@@ -280,7 +280,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
           - rubocop-rspec
       YAML
 
-      config.add_plugin(%w(rubocop-gusto))
+      config.add_plugin(%w[rubocop-gusto])
 
       expect(config.to_s).to eq(<<~YAML)
         plugins:
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
         - rubocop-rspec
       YAML
 
-      config.add_plugin(%w(rubocop-gusto))
+      config.add_plugin(%w[rubocop-gusto])
 
       expect(config.to_s).to eq(<<~YAML)
         plugins:
@@ -382,7 +382,7 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
       YAML
     end
 
-    it "it handles the case where there are cops before preamble" do
+    it "handles the case where there are cops before preamble" do
       config = described_class.new(<<~YAML.lines)
         RSpec/AnyInstance:
           Enabled: true

--- a/spec/rubocop/gusto_spec.rb
+++ b/spec/rubocop/gusto_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Gusto do
         suggestion = start_with_subject[:verb]&.capitalize if start_with_subject
         suggestion ||= "a verb"
         expect(start_with_subject.nil?).to(
-          be(true), "`Description` for `#{name}` should be started with `#{suggestion}` instead of `This cop ...`."
+          be(true), "`Description` for `#{name}` should be started with `#{suggestion}` instead of `This cop ...`.",
         )
       end
     end
@@ -47,10 +47,12 @@ RSpec.describe RuboCop::Gusto do
     end
 
     it "sorts configuration keys alphabetically" do
+      preamble_keys = %w[inherit_mode plugins AllCops]
       ["config/default.yml", "config/rails.yml"].each do |config_file|
         config_keys = RuboCop::ConfigLoader.load_file(config_file)
-        expected = config_keys.keys.sort
-        config_keys.each_key.with_index do |key, idx|
+        cop_keys = config_keys.keys.reject { |k| preamble_keys.include?(k) }
+        expected = cop_keys.sort
+        cop_keys.each_with_index do |key, idx|
           expect(key).to eq(expected[idx]), "Cops should be sorted. Please sort with `bundle exec exe/rubocop-gusto sort #{config_file}`."
         end
       end
@@ -80,8 +82,8 @@ RSpec.describe RuboCop::Gusto do
       fname = File.expand_path("../../config/default.yml", __dir__)
       content = File.read(fname)
       errors = []
-      RuboCop::YAMLDuplicationChecker.check(content, fname) do |key_1, key_2|
-        errors.push("#{fname} has duplication of #{key_1.value} on line #{key_1.start_line} and line #{key_2.start_line}")
+      RuboCop::YAMLDuplicationChecker.check(content, fname) do |key1, key2|
+        errors.push("#{fname} has duplication of #{key1.value} on line #{key1.start_line} and line #{key2.start_line}")
       end
 
       expect(errors).to be_empty
@@ -109,7 +111,7 @@ RSpec.describe RuboCop::Gusto do
       config_default = YAML.load_file("config/default.yml")
 
       config_default.each_key do |key|
-        next if %w(inherit_mode AllCops plugins).include?(key)
+        next if %w[inherit_mode AllCops plugins].include?(key)
 
         expect(previous_key <= key).to be(true), "Cops should be sorted alphabetically. Please sort #{key} before #{previous_key}."
         previous_key = key


### PR DESCRIPTION
## Summary

Establishes `config/default.yml` and `config/rails.yml` as the new standard RuboCop configuration for Gusto Ruby projects — services, gems, and any other Ruby codebase. The existing configuration is moved to `config/default-legacy.yml` and `config/rails-legacy.yml`, which are retained for codebases that continue to use them while adopting the new configs on their own timeline.

The new configuration is a clean-slate replacement of the legacy config, applying only rules that are justified by an explicit priority framework. The work proceeded in phases: initial configuration, calibration against production codebase data, integration testing against real gems and the monolith, and iterative refinement based on what those tests revealed.

---

## Configuration

### Priority framework

All cop decisions are justified by an explicit ordered framework: Sorbet compatibility → correctness/safety → diff quality → agent consistency → idiomatic modern Ruby → performance. The framework and decision process are documented in `prompts/update-rubocop-config.md`.

### Sorbet compatibility
- Disable `Style/ArgumentsForwarding` — `...` forwarding is unsupported by Sorbet's type inference
- Disable `Performance/RedundantBlockCall` — autocorrect removes `&blk` from parameter lists that Sorbet sigs reference, breaking the sig
- Disable `RSpec/DescribedClass` — `described_class::Const` always raises Sorbet error 5002; the RSpec maintainer has also called it an anti-pattern
- Disable `Style/ModuleFunction: forbidden` — Sorbet cannot enforce the singleton version of module function methods
- Enable `Sorbet/Refinement` (pending upstream, Gusto contribution) — refinements are unsupported by Sorbet
- Enable `Sorbet/StrictSigil` and `Sorbet/ValidSigil` to enforce `typed: strict` on all production files from day one

### Correctness and safety
- Elevate `Lint/SelfAssignment`, `Lint/UnexpectedBlockArity`, `Lint/Void`, `Gusto/MinByMaxBy` to `Severity: error`
- Enable `Lint/SharedMutableDefault`, `Lint/UselessConstantScoping` (both pending)
- Enable `Lint/Void: CheckForMethodsWithNoSideEffects: true` — catches `arr.sort` when result is discarded
- Enable `Rails/SaveBang`, `Rails/DefaultScope`, `Rails/ReversibleMigrationMethodDefinition` (all disabled by default)
- Enable 10 additional Rails pending cops covering duplicate associations/scopes, transaction exit statements, flash-before-render, `where.not` with multiple conditions, and others

### Diff quality and agent consistency
- Fix `Style/TrailingCommaIn{Array,Hash}Literal` — parameter name was wrong (`EnforcedStyle` instead of `EnforcedStyleForMultiline`), silently leaving `no_comma` in effect
- Add `Style/TrailingCommaInArguments: consistent_comma`
- Set `Style/AccessModifierDeclarations: inline` — agents have been observed placing public methods inside `private` groups, which produces CI failures not caught by static analysis
- Enable `Layout/First{Array,Hash,MethodArgument,MethodParameter}ElementLineBreak` and `Layout/ArgumentAlignment: with_fixed_indentation` for canonical multiline shapes that don't break on rename
- Disable `Style/RedundantSelf` — `self.foo` clarifies method vs. variable; `self.ignored_columns =` and `ignored_columns =` have different semantics
- Disable `Style/IfUnlessModifier` — converts complex compound conditions to trailing modifiers, burying the condition at the end of long lines
- `Style/ClassAndModuleChildren: Enabled: true` (upstream default kept); spec files excluded from the cop because the unsafe autocorrect converts `class described_class::Foo` to `module described_class / class Foo`, a syntax error — `described_class` is a method call, not a module constant. The correct fix is to replace `described_class` with the actual class name, consistent with `RSpec/DescribedClass: Enabled: false`

### Numeric limits
All Metrics limits and RSpec limits calibrated at the 95th percentile of production Gusto codebases, with `Metrics/ParameterLists: CountKeywordArgs: false` (keyword args are self-documenting at call sites) and `Metrics/ClassLength: CountAsOne: [array, hash]` (data tables inflate class length without reflecting logic complexity).

### Gusto cops
All 22 `Gusto/*` cops registered with full YARD documentation comments (`@example`, `@safety`, `@see`). Include/exclude patterns sized for standalone projects. `Gusto/DiscouragedGem` disabled by default; enabled in `rails.yml` with a timecop entry.

---

## Integration testing

The configuration was tested against five gems in `rubyatscale` and against two large-scale production monoliths:

- `danger-migrations`, `typed_enum` — initial integration; revealed `Style/ClassAndModuleChildren` unsafe autocorrect, `RSpec/NamedSubject: named_only`, `Gusto/NoMetaprogramming` spec exclusion, `Metrics/ParameterLists: CountKeywordArgs: false`, `RSpec/NestedGroups: Max: 5`
- `rubocop-packs`, `packs`, `code_teams` — broader coverage across the rubyatscale ecosystem
- First monolith — 17,801 files, 527K+ offenses autocorrected; revealed `Style/RedundantSelf`, `Style/IfUnlessModifier`, `Layout/ArgumentAlignment` as counterproductive, and `RSpec/NamedSubject: always` producing 35K violations at scale
- Second monolith — validated Metrics limits and additional Rails cops against a second large production codebase; confirmed 95th-percentile calibration holds across both

---

## Upstream rubocop fix

`Style/AccessModifierDeclarations` inline autocorrect was found to silently drop comments between a standalone `private` declaration and the first method definition. A fix was contributed upstream: rubocop/rubocop#15072.

---

## Other changes

- `prompts/update-rubocop-config.md` — agent prompt for reviewing and updating the configuration, covering the priority framework, full parameter evaluation, numeric limit guidance, CI cost framing, pending cop policy, and configuration stability guidance
- YARD documentation added to all 22 `Gusto/*` cop classes
- Spec fix: the "sorts configuration keys alphabetically" test incorrectly compared `inherit_mode` (lowercase) against uppercase cop namespace keys; fixed to skip preamble keys

---

## Test plan

- [x] `bundle exec rspec` passes (335 examples, 0 failures)
- [x] `bundle exec rubocop-gusto sort config/default.yml` produces no changes
- [x] `bundle exec rubocop-gusto sort config/rails.yml` produces no changes
- [x] Tested against 5 rubyatscale gems — all reach zero offenses
- [x] Tested against two production monoliths — 17,801+ files inspected across both; no offenses after fixes and `.rubocop_todo.yml` for legacy debt

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the changelog folder named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See changelog entry format for details.

