### PR TITLE
feat: enable StringLiteralsFrozenByDefault in AllCops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -17,6 +17,7 @@ AllCops:
     - 'db/seeds{.rb,/**/*}'
   DisplayCopNames: true
   NewCops: disable
+  StringLiteralsFrozenByDefault: true
   SuggestExtensions: false
 
 Bundler/OrderedGems:


### PR DESCRIPTION
## Summary

Adds `StringLiteralsFrozenByDefault: true` to the `AllCops` section in `config/default.yml`, opting into RuboCop's [globally-frozen string literals](https://docs.rubocop.org/rubocop/latest/configuration.html#opting-into-globally-frozen-string-literals) behavior.

This lets cops that depend on the assumption (e.g. `Style/FrozenStringLiteralComment`, `Style/MutableConstant`) treat string literals as frozen without requiring per-file `# frozen_string_literal: true` magic comments.

## Test plan

- [ ] CI passes