### PR TITLE
ci: install gems before rake release; add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore"
+  - package-ecosystem: github-actions
+    rebase-strategy: auto
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           bundler-cache: false
           ruby-version: ruby
+      - name: Install gems
+        run: bundle install --jobs 4
 
       # Release
       - uses: rubygems/release-gem@1c162a739e8b4cb21a676e97b087e8268d8fc40b # v1.1.2


### PR DESCRIPTION
## Summary

- Add an explicit `bundle install` step to the release workflow. We set `bundler-cache: false` for zizmor's cache-poisoning protection, but never ran `bundle install`, so `rubygems/release-gem`'s `bundle exec rake release` blew up with `Bundler::GemNotFound`. This is what broke the [v10.9.0 release run](https://github.com/Gusto/rubocop-gusto/actions/runs/26299096769/job/77419337986).
- Add a `github-actions` ecosystem to dependabot (monthly, all actions grouped, `ci:` commit prefix) so action SHA pins get refreshed alongside the bundler updates.

## Note on `--jobs 4`

The `--jobs 4` flag mirrors what `setup-ruby`'s own `bundler-cache: true` path uses internally and is the most common pattern in the wider ecosystem, so it's the safe default. The practical impact here is small: this workflow runs once per release on a fresh GitHub-hosted runner (2 cores) installing ~40 gems, and `--jobs` higher than the core count gives diminishing returns for a CPU-bound install. Plain `bundle install` would work equivalently — happy to drop the flag if preferred.

## Follow-up

The v10.9.0 release was tagged and a GitHub release was created, but the gem never reached RubyGems. After this lands we'll need to either re-run the failed v10.9.0 workflow or cut v10.9.1.

## Test plan

- [ ] Merge to main; release-please opens its next Release PR
- [ ] Merging that Release PR successfully publishes the gem to RubyGems
