### PR TITLE
fix: upload gem from pkg/ to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$RELEASE_TAG" rubocop-gusto-*.gem
+        run: gh release upload "$RELEASE_TAG" pkg/rubocop-gusto-*.gem


### PR DESCRIPTION
## Summary

The `Upload gem to release` step in `.github/workflows/release.yml` globbed `rubocop-gusto-*.gem` at the repo root, but `rake release` builds the gem into `pkg/`, so the glob never matched:

```
no matches found for `rubocop-gusto-*.gem`
```

This step has `continue-on-error: true` (defensively, for IP-allowlist transient failures), so every successful release silently published to RubyGems without attaching the `.gem` artifact to the GitHub release. The v10.9.1 run is the most recent example: https://github.com/Gusto/rubocop-gusto/actions/runs/26301435908/job/77446235227

This PR fixes the glob to `pkg/rubocop-gusto-*.gem`, matching how `rubygems/release-gem` itself awaits the file (`pkg/*.gem`).

## Test plan

- [ ] Next release attaches the `.gem` to the GitHub release page

## Follow-up

The v10.9.1 release page doesn't have its `.gem` attached. Easy to upload retroactively once this lands — happy to do that separately.