### PR TITLE
feat: Set EnforcedShorthandSyntax to 'always'

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -480,6 +480,7 @@ Style/GuardClause:
 
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
+  EnforcedShorthandSyntax: always
 
 Style/HashTransformKeys:
   Enabled: false

--- a/lib/rubocop/cop/gusto/discouraged_gem.rb
+++ b/lib/rubocop/cop/gusto/discouraged_gem.rb
@@ -34,7 +34,7 @@ module RuboCop
         end
 
         def message_for(gem)
-          format(MSG, gem: gem, advice: advice_for(gem))
+          format(MSG, gem:, advice: advice_for(gem))
         end
 
         def advice_for(gem)

--- a/lib/rubocop/cop/rack/lowercase_header_keys.rb
+++ b/lib/rubocop/cop/rack/lowercase_header_keys.rb
@@ -122,9 +122,9 @@ module RuboCop
 
         def add_offense_for_header(node, key_value)
           downcased = key_value.downcase
-          message = format(MSG, downcased: downcased, original: key_value)
+          message = format(MSG, downcased:, original: key_value)
 
-          add_offense(node, message: message) do |corrector|
+          add_offense(node, message:) do |corrector|
             corrector.replace(node, "'#{downcased}'")
           end
         end


### PR DESCRIPTION
I was asked [here](https://gustohq.slack.com/archives/C01FR8B83R6/p1779393867217769) to create this PR. I have a test [here](https://github.com/Gusto/zenpayroll/pull/342404) to ensure that it works without issue in ZP.

---

Enable the Rubocop rule `EnforcedShorthandSyntax: always`. This would force code like this:

```
{ foo: foo, bar: bar }
func(foo: foo, bar: bar)
```

to be written like this instead:

```
{ foo:, bar: }
func(foo:, bar:)
```

Notes:
* Code like `{ foo:, bar: company.id }` is still acceptable under this rule. It only complains when the parameter name and the variable name are the same.
* It's auto-fixable, so it shouldn't cause any extra burden on developers/AI