### PR TITLE
fix: stop overriding AllCops scope in shared configs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -8,13 +8,6 @@ plugins:
 
 AllCops:
   TargetRubyVersion: <%= RbConfig::CONFIG['RUBY_API_VERSION'] %>
-  MaxFilesInCache: 100000
-  Exclude:
-    - './.[!.]*' # ignore all dotfiles
-    - './.[!.]*/**/*' # ignore all dot directories
-    - 'config/boot.rb'
-    - 'db/**/*schema.rb'
-    - 'db/seeds{.rb,/**/*}'
   DisplayCopNames: true
   NewCops: disable
   SuggestExtensions: false

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -9,13 +9,6 @@ plugins:
 AllCops:
   ActiveSupportExtensionsEnabled: true
   TargetRubyVersion: <%= RbConfig::CONFIG['RUBY_API_VERSION'] %>
-  MaxFilesInCache: 100000
-  Exclude:
-    - './.[!.]*' # ignore all dotfiles
-    - './.[!.]*/**/*' # ignore all dot directories
-    - 'config/boot.rb'
-    - 'db/**/*schema.rb'
-    - 'db/seeds{.rb,/**/*}'
 
 Gusto/DiscouragedGem:
   Enabled: true


### PR DESCRIPTION
## Summary
- Drops the `AllCops.Exclude` block from both `config/default.yml` and `config/rails.yml`. These global exclusions silently disabled every cop (including the [Security](https://docs.rubocop.org/rubocop/latest/cops_security.html) cops and forward-compatibility cops like `Style/FrozenStringLiteralComment`) for dotfiles, `config/boot.rb`, `db/**/*schema.rb`, and `db/seeds*`.
- Drops the `AllCops.MaxFilesInCache: 100000` override from both configs. This is a per-project cache-tuning value that depends on the consuming project's file count — a shared config shouldn't pin it. Falls back to RuboCop's default (20000).
- Consuming projects that still want either of these behaviors can re-add them to their own `.rubocop.yml`.

## Test plan
- [x] `bundle exec rspec` — 354 examples, 0 failures, 100% line + branch coverage
- [x] `bundle exec rubocop` — clean
