### PR TITLE
fix: clean up Sorbet config and allow RBS inline annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ PR titles must use [Conventional Commits](https://www.conventionalcommits.org/) 
 - `feat!:` — breaking change (major bump)
 - `chore:`, `docs:`, `ci:` — no release
 
+A change in the set of violations a cop reports (enabling/tightening a cop, removing an
+`Exclude`, changing an `EnforcedStyle`) is **not** by itself a breaking change. Consuming
+projects can suppress new offenses via `.rubocop_todo.yml` or their own config, so these
+ship as `feat:` or `fix:`. Reserve `feat!:` for changes to the gem's own API or plugin
+interface that require consumers to change their configuration to keep working.
+
 Releases are automated via release-please: merge the auto-generated Release PR to publish.
 
 ## What this is

--- a/config/default.yml
+++ b/config/default.yml
@@ -176,6 +176,9 @@ Layout/FirstMethodArgumentLineBreak:
 Layout/FirstMethodParameterLineBreak:
   Enabled: true
 
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
 Layout/LineLength:
   # TODO: Pick some maximum like 200 to start with
   Enabled: false
@@ -370,12 +373,9 @@ Rack/LowercaseHeaderKeys:
 Rake/ClassDefinitionInTask:
   Enabled: false
 
-Sorbet:
-  # TODO: validate these choices for Harmonization
-  # BindingConstantWithoutTypeAlias
-  # EnforceSigilOrder # verify this works with Teams annotations
-  # ForbidUntypedStructProps
-  # SignatureBuildOrder
+Sorbet/ForbidTUnsafe:
+  # T.unsafe completely disables typechecking. Prefer T.cast, shims, or
+  # reorganizing the code over silently turning off the type checker.
   Enabled: true
 
 Sorbet/Refinement:
@@ -387,21 +387,10 @@ Sorbet/StrictSigil:
   # Check this out: https://sorbet.org/docs/static#file-level-granularity-strictness-levels
   Enabled: true
   Exclude:
-  - bin/**/*
-  - db/**/*.rb
-  - script/**/*
   - spec/**/*spec.rb
 
 Sorbet/ValidSigil:
   RequireSigilOnAllFiles: true
-  # We don't want to require any specific typed level at this point – only that there IS a typed sigil.
-  MinimumStrictness: ignore
-  # We do suggest that the user type their file as `typed: strict`
-  SuggestedStrictness: strict
-  Exclude:
-    - '**/db/migrate/**/*'
-    - '**/*.{rake,arb,erb,rabl}'
-    - '**/{Gemfile,Rakefile}'
 
 Style/AccessorGrouping:
   Enabled: false


### PR DESCRIPTION
## What

Tidies up the shared RuboCop config (`config/default.yml`), focused on the Sorbet department, plus a small RBS allowance and a contributing-docs note.

### `config/default.yml`

- **`Layout/LeadingCommentSpace`** — add `AllowRBSInlineAnnotation: true` so RBS inline annotation comments (e.g. `#: String`) are exempt from the leading-space requirement. RBS comments are rare in our source but should not be flagged.
- **Remove the `Sorbet:` department block** — drop the top-level `Sorbet: Enabled: true` and its stale `# TODO: validate these choices for Harmonization` comments. It was a no-op: every Sorbet cop is configured individually, and a department-level `Enabled: true` does **not** enable pending cops either — only `AllCops: NewCops: enable` (global) or a per-cop `Enabled: true` does. (Verified by running a pending cop under each config.)
- **Enable `Sorbet/ForbidTUnsafe`** — upstream default is `Enabled: false`. `T.unsafe` completely disables typechecking; we'd rather use `T.cast`, shims, or reorganize the code than silently turn off the type checker.
- **`Sorbet/StrictSigil`** — remove the redundant `bin/**/*`, `db/**/*.rb`, and `script/**/*` exclusions. The cop now applies to those files; only `spec/**/*spec.rb` remains excluded. (rubocop-sorbet default: [`Sorbet/StrictSigil`](https://github.com/Shopify/rubocop-sorbet/blob/main/config/default.yml#L389-L399))
- **`Sorbet/ValidSigil`** — drop the custom `MinimumStrictness: ignore` and `SuggestedStrictness: strict`, reverting both to the [rubocop-sorbet defaults](https://github.com/Shopify/rubocop-sorbet/blob/main/config/default.yml#L437-L451) (`MinimumStrictness: nil`, `SuggestedStrictness: "false"`), and remove the redundant `Exclude` entries. `.rake` files are now included; the `Gemfile`/`Rakefile`/`.arb`/`.erb`/`.rabl`/`db/migrate` exclusions were redundant.

### `AGENTS.md`

- Document that a change in the set of violations a cop reports (enabling/tightening a cop, removing an `Exclude`, changing an `EnforcedStyle`) is **not** by itself a breaking change — consumers can suppress new offenses via `.rubocop_todo.yml` — and that `feat!:` is reserved for changes to the gem's own API or plugin interface.

### Note on `ValidSigil` strictness

`MinimumStrictness` is not what forbids `typed: ignore`. With it unset (`nil`, the default), `ValidSigil` only checks that a valid sigil is present — `typed: ignore` passes, same as under the old `MinimumStrictness: ignore`. Forbidding `typed: ignore` is already handled by [`Sorbet/FalseSigil`](https://github.com/Shopify/rubocop-sorbet/blob/main/config/default.yml#L112-L116) ("All files must be at least at strictness `false`"), which is enabled by default. So `ValidSigil` doesn't need to enforce a minimum here; the only behavioral change is the level it suggests / auto-adds for un-sigiled files: previously `typed: strict`, now `typed: false`.

## Why this is `fix:` and not `feat!:`

A change in the set of violations a cop reports (enabling/tightening a cop, removing an `Exclude`) is not by itself a breaking change. Consuming projects can suppress new offenses via `.rubocop_todo.yml` or their own config, so these ship as `fix:`/`feat:`. `feat!:` is reserved for changes to the gem's own API or plugin interface. Enabling `Sorbet/ForbidTUnsafe` and tightening the sigil cops will surface new offenses in consuming projects on upgrade — expected, and suppressible via `.rubocop_todo.yml`.
