### PR TITLE
fix: update ExecuteMigration cop to recommend backfill sidekiq job

### DIFF
--- a/lib/rubocop/cop/gusto/execute_migration.rb
+++ b/lib/rubocop/cop/gusto/execute_migration.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Gusto
       class ExecuteMigration < Base
-        MSG = "Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method."
+        MSG = "Do not use `execute` to run raw SQL in a migration. Run the query from a backfill sidekiq job or pass the SQL options to the `add_column`/`change_column` method."
         RESTRICT_ON_SEND = [:execute].freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/gusto/execute_migration_spec.rb
+++ b/spec/rubocop/cop/gusto/execute_migration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Gusto::ExecuteMigration, :config do
       class CreateUsers < ActiveRecord::Migration[6.0]
         def change
           execute("CREATE TABLE users (id int)")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill sidekiq job or pass the SQL options to the `add_column`/`change_column` method.
         end
       end
     RUBY
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Gusto::ExecuteMigration, :config do
       class AddIndexToUsers < ActiveRecord::Migration[6.0]
         def up
           execute("CREATE INDEX index_users_on_email ON users (email)")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill sidekiq job or pass the SQL options to the `add_column`/`change_column` method.
         end
       end
     RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::Gusto::ExecuteMigration, :config do
       class AddIndexToUsers < ActiveRecord::Migration[6.0]
         def down
           execute("DROP INDEX index_users_on_email")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `execute` to run raw SQL in a migration. Run the query from a backfill sidekiq job or pass the SQL options to the `add_column`/`change_column` method.
         end
       end
     RUBY


### PR DESCRIPTION
## Human summary
This PR is in response to a conversation with Peter Compernolle, where in Hawaiian Ice, they intentionally leverage sidekiq over rake. Currently in backend services there is no mechanism to use rake, so this error message sends claude in the wrong direction.

See https://gustohq.slack.com/archives/C01B8LB64TC/p1780096218787349 for more details.

## Summary

- Updates the `ExecuteMigration` cop message to recommend a backfill sidekiq job instead of a backfill rake task
- Updates the corresponding spec fixtures to match the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)