### PR TITLE
build: point test image gem mirror at Cloudsmith

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.10.0
 FROM ruby:3.2-alpine
 
 RUN addgroup -g 9999 -S buildkite-agent \
@@ -8,14 +9,15 @@ WORKDIR $APP_HOME
 
 RUN bundle config --local app_config /usr/local/bundle/config \
  && bundle config --local path vendor/bundle \
- && bundle config --local "mirror.https://rubygems.org" "https://gemstash.zp-int.com" \
+ && bundle config --local "mirror.https://rubygems.org" "https://dl.cloudsmith.io/basic/gusto/gusto/ruby/" \
  && mkdir /home/buildkite-agent/.gem
 
 COPY Gemfile* rubocop-gusto.gemspec $APP_HOME/
 COPY lib/rubocop/gusto/version.rb $APP_HOME/lib/rubocop/gusto/version.rb
 
-RUN apk add --no-cache build-base \
- && bundle install \
+RUN --mount=type=secret,id=cloudsmith_api_key,env=CLOUDSMITH_API_KEY \
+    apk add --no-cache build-base \
+ && BUNDLE_DL__CLOUDSMITH__IO="token:${CLOUDSMITH_API_KEY}" bundle install \
  && apk del build-base
 
 COPY . $APP_HOME


### PR DESCRIPTION
Part of the org-wide migration off the legacy gemstash gem mirror (gemstash.zp-int.com) onto Cloudsmith.

## Why
The gemstash mirror is being decommissioned. `Dockerfile.test` configured bundler to mirror rubygems.org through `https://gemstash.zp-int.com`; that endpoint is going away.

## What changed
- `Dockerfile.test`: repoint the `mirror.https://rubygems.org` bundler config from gemstash to the Cloudsmith rubygems proxy (`https://dl.cloudsmith.io/basic/gusto/gusto/ruby/`).
- Add the BuildKit syntax directive, a `cloudsmith_api_key` secret mount, and `BUNDLE_DL__CLOUDSMITH__IO="token:${CLOUDSMITH_API_KEY}"` on the `bundle install` RUN so the authenticated Cloudsmith host is reachable.

## Read path / publish path scope
This was the only gemstash reference in the repo. The Gemfile, Gemfile.lock, and all dependencies use public rubygems.org and were left untouched. The gem publishes to **rubygems.org** (release-please + `rubygems/release-gem` GitHub Action; gemspec `allowed_push_host` defaults to rubygems.org) — the publish path is intentionally **not** changed.

## Gemfile.lock
Not modified. No private/quarantined gems are involved; the lockfile already resolves entirely from rubygems.org.

## Note on CI coverage
Repo CI (`build.yml`, `release.yml`) runs on GitHub Actions via `ruby/setup-ruby` and does not build `Dockerfile.test`, so this change is not exercised by an automated build. It removes the dangling gemstash reference so the image still builds once gemstash is gone.

## Validation
No automated build exercises `Dockerfile.test`. Change is a mechanical mirror-endpoint swap following the canonical Cloudsmith Dockerfile pattern (secret mount + `BUNDLE_DL__CLOUDSMITH__IO`).

## Rollback
Revert this commit; the image returns to the gemstash mirror.