### PR TITLE
feat: add Gusto/DescribedClassConstantReference cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -42,6 +42,13 @@ Gusto/DatadogConstant:
     - '**/spec/**/*'
   Description: 'Do not call Datadog directly, use an appropriate wrapper library.'
 
+Gusto/DescribedClassConstantReference:
+  Description: 'Flags constants scoped through `described_class` (e.g. `described_class::Foo`), which Sorbet cannot resolve statically.'
+  Enabled: true
+  SafeAutoCorrect: false
+  Include:
+    - '**/spec/**/*'
+
 Gusto/DiscouragedGem:
   Description: 'Flags installation of discouraged gems in Gemfiles and gemspecs.'
   Enabled: false

--- a/lib/rubocop/cop/gusto/described_class_constant_reference.rb
+++ b/lib/rubocop/cop/gusto/described_class_constant_reference.rb
@@ -17,7 +17,10 @@ module RuboCop
       # enclosing example group describes. It is marked unsafe
       # (`SafeAutoCorrect: false`) because the rewrite relies on the described
       # constant being a statically-written name; review the result before
-      # committing.
+      # committing. In particular, a constant defined on an *ancestor* of the
+      # described class is qualified against the described class itself, which
+      # is correct at runtime but which Sorbet cannot resolve through the
+      # inheritance chain -- re-point those to the defining ancestor by hand.
       #
       # @example
       #   # bad
@@ -29,6 +32,13 @@ module RuboCop
       #   # good
       #   RSpec.describe Payments::Processor do
       #     describe Payments::Processor::Worker do
+      #     end
+      #   end
+      #
+      #   # good - `RSpec.describe self` resolves to the enclosing namespace
+      #   module Payments
+      #     RSpec.describe self do
+      #       it { expect(Payments::TIMEOUT).to eq(5) }
       #     end
       #   end
       #
@@ -49,24 +59,19 @@ module RuboCop
           (const (send nil? :described_class) _)
         PATTERN
 
-        # `described_class` called with no explicit receiver.
-        # @!method described_class_call?(node)
-        def_node_matcher :described_class_call?, <<~PATTERN
-          (send nil? :described_class)
-        PATTERN
-
-        # An example group whose first argument is a constant, capturing that
-        # constant: `RSpec.describe Foo do`, `describe Foo do`, `context Foo do`.
-        # @!method example_group_described_constant(node)
-        def_node_matcher :example_group_described_constant, <<~PATTERN
+        # An example group, capturing its first argument: a constant
+        # (`RSpec.describe Foo do`, `context Foo do`), `self`
+        # (`RSpec.describe self do`), and so on.
+        # @!method example_group_described_argument(node)
+        def_node_matcher :example_group_described_argument, <<~PATTERN
           (block
             (send {(const nil? :RSpec) nil?}
               {:describe :xdescribe :fdescribe :context :xcontext :fcontext :feature :example_group}
-              $const ...)
+              $_ ...)
             ...)
         PATTERN
 
-        # Whether a constant subtree routes through `described_class`.
+        # Whether a node routes through a no-receiver `described_class`.
         # @!method scoped_through_described_class?(node)
         def_node_search :scoped_through_described_class?, <<~PATTERN
           (send nil? :described_class)
@@ -77,33 +82,49 @@ module RuboCop
 
           scope = node.children[0]
           add_offense(scope) do |corrector|
-            described_constant = lexical_described_constant(node)
-            corrector.replace(scope, described_constant.source) if described_constant
+            replacement = described_class_replacement(node)
+            corrector.replace(scope, replacement) if replacement
           end
         end
 
         private
 
-        # The constant that `described_class` resolves to lexically: the nearest
-        # enclosing example group whose described constant does not itself route
-        # through `described_class`.
+        # The fully-qualified name (as a String) that `described_class` resolves
+        # to lexically, from the nearest enclosing example group, or nil if it
+        # cannot be determined statically.
         #
-        # When the nearest enclosing group is described via `described_class::X`,
-        # the reference is only resolvable if it *is* that describe argument
-        # (e.g. `describe described_class::Worker` qualifies against the outer
-        # group). A reference in such a group's *body* resolves at runtime to
-        # the scoped (and statically unknown) class, so we decline to autocorrect
-        # rather than qualify it against the wrong ancestor. Once the enclosing
-        # `described_class::X` is itself rewritten, a later pass resolves the
-        # body reference correctly.
-        def lexical_described_constant(node)
+        # - `describe SomeClass` resolves to that constant's written name.
+        # - `describe self` resolves to the enclosing module/class namespace.
+        # - `describe described_class::X` qualifies the describe argument itself
+        #   against the outer group; a reference in such a group's *body* resolves
+        #   at runtime to the scoped (statically unknown) class, so we decline to
+        #   autocorrect it. Once the enclosing `described_class::X` is rewritten,
+        #   a later pass resolves the body reference correctly.
+        # - Any other describe argument (e.g. a string) is skipped, and the
+        #   search continues at the next enclosing example group.
+        def described_class_replacement(node)
           node.each_ancestor(:block) do |block_node|
-            described_constant = example_group_described_constant(block_node)
-            next unless described_constant
-            return described_constant unless scoped_through_described_class?(described_constant)
-            return nil unless reference_within_described_constant?(described_constant, node)
+            described_argument = example_group_described_argument(block_node)
+            next if described_argument.nil?
+
+            if described_argument.self_type?
+              namespace = enclosing_namespace(block_node)
+              return namespace if namespace
+            elsif described_argument.const_type?
+              return described_argument.source unless scoped_through_described_class?(described_argument)
+              return nil unless reference_within_described_constant?(described_argument, node)
+            end
           end
           nil
+        end
+
+        # The fully-qualified name of the module/class lexically enclosing the
+        # example group, which is what `self` refers to in `RSpec.describe self`.
+        def enclosing_namespace(block_node)
+          names = block_node.each_ancestor(:class, :module).map { |mod| mod.children.first.source }
+          return if names.empty?
+
+          names.reverse.join("::")
         end
 
         # Whether the offending constant is the described constant itself (the

--- a/lib/rubocop/cop/gusto/described_class_constant_reference.rb
+++ b/lib/rubocop/cop/gusto/described_class_constant_reference.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Flags constants that are scoped through `described_class`, e.g.
+      # `described_class::Worker`.
+      #
+      # `described_class` is an RSpec helper method resolved at runtime, so
+      # Sorbet's static analysis treats `described_class::Worker` as a dynamic
+      # constant reference and cannot resolve it (`Dynamic constant references
+      # are unsupported`, https://srb.help/5001). Reference the constant by its
+      # fully-qualified name instead. A bare `described_class` (with no `::`
+      # constant lookup) is an ordinary method call and is left alone.
+      #
+      # Autocorrection replaces `described_class` with the constant that the
+      # enclosing example group describes. It is marked unsafe
+      # (`SafeAutoCorrect: false`) because the rewrite relies on the described
+      # constant being a statically-written name; review the result before
+      # committing.
+      #
+      # @example
+      #   # bad
+      #   RSpec.describe Payments::Processor do
+      #     describe described_class::Worker do
+      #     end
+      #   end
+      #
+      #   # good
+      #   RSpec.describe Payments::Processor do
+      #     describe Payments::Processor::Worker do
+      #     end
+      #   end
+      #
+      #   # good - a bare `described_class` is not a constant reference
+      #   RSpec.describe Payments::Processor do
+      #     subject { described_class.new }
+      #   end
+      class DescribedClassConstantReference < Base
+        extend AutoCorrector
+
+        MSG = "Use the fully-qualified constant name instead of scoping it through " \
+              "`described_class`, which Sorbet cannot resolve statically."
+
+        # A constant whose scope is a no-receiver `described_class`, e.g.
+        # `described_class::Worker`.
+        # @!method const_scoped_on_described_class?(node)
+        def_node_matcher :const_scoped_on_described_class?, <<~PATTERN
+          (const (send nil? :described_class) _)
+        PATTERN
+
+        # `described_class` called with no explicit receiver.
+        # @!method described_class_call?(node)
+        def_node_matcher :described_class_call?, <<~PATTERN
+          (send nil? :described_class)
+        PATTERN
+
+        # An example group whose first argument is a constant, capturing that
+        # constant: `RSpec.describe Foo do`, `describe Foo do`, `context Foo do`.
+        # @!method example_group_described_constant(node)
+        def_node_matcher :example_group_described_constant, <<~PATTERN
+          (block
+            (send {(const nil? :RSpec) nil?}
+              {:describe :xdescribe :fdescribe :context :xcontext :fcontext :feature :example_group}
+              $const ...)
+            ...)
+        PATTERN
+
+        # Whether a constant subtree routes through `described_class`.
+        # @!method scoped_through_described_class?(node)
+        def_node_search :scoped_through_described_class?, <<~PATTERN
+          (send nil? :described_class)
+        PATTERN
+
+        def on_const(node)
+          return unless const_scoped_on_described_class?(node)
+
+          scope = node.children[0]
+          add_offense(scope) do |corrector|
+            described_constant = lexical_described_constant(node)
+            corrector.replace(scope, described_constant.source) if described_constant
+          end
+        end
+
+        private
+
+        # The constant that `described_class` resolves to lexically: the nearest
+        # enclosing example group whose described constant does not itself route
+        # through `described_class`.
+        #
+        # When the nearest enclosing group is described via `described_class::X`,
+        # the reference is only resolvable if it *is* that describe argument
+        # (e.g. `describe described_class::Worker` qualifies against the outer
+        # group). A reference in such a group's *body* resolves at runtime to
+        # the scoped (and statically unknown) class, so we decline to autocorrect
+        # rather than qualify it against the wrong ancestor. Once the enclosing
+        # `described_class::X` is itself rewritten, a later pass resolves the
+        # body reference correctly.
+        def lexical_described_constant(node)
+          node.each_ancestor(:block) do |block_node|
+            described_constant = example_group_described_constant(block_node)
+            next unless described_constant
+            return described_constant unless scoped_through_described_class?(described_constant)
+            return nil unless reference_within_described_constant?(described_constant, node)
+          end
+          nil
+        end
+
+        # Whether the offending constant is the described constant itself (the
+        # describe argument) rather than a reference inside the group's body.
+        def reference_within_described_constant?(described_constant, node)
+          node.equal?(described_constant) ||
+            described_constant.each_descendant(:const).any? { |const_node| const_node.equal?(node) }
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/described_class_constant_reference_spec.rb
+++ b/spec/rubocop/cop/gusto/described_class_constant_reference_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gusto::DescribedClassConstantReference, :config do
+  context "when a constant is scoped through described_class" do
+    it "registers an offense and rewrites the describe argument to the fully-qualified constant" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe described_class::Worker do
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe Payments::Processor::Worker do
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense and rewrites a reference inside an example" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "returns the const" do
+            expect(described_class::TIMEOUT).to eq(5)
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "returns the const" do
+            expect(Payments::Processor::TIMEOUT).to eq(5)
+          end
+        end
+      RUBY
+    end
+
+    it "registers a single offense for a deeply nested constant and qualifies the leading scope" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "references a deeply nested const" do
+            described_class::Config::Timeout
+            ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "references a deeply nested const" do
+            Payments::Processor::Config::Timeout
+          end
+        end
+      RUBY
+    end
+
+    it "resolves a reference inside an aliased example group (feature)" do
+      expect_offense(<<~RUBY)
+        RSpec.feature Payments::Processor do
+          it "returns the const" do
+            expect(described_class::TIMEOUT).to eq(5)
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.feature Payments::Processor do
+          it "returns the const" do
+            expect(Payments::Processor::TIMEOUT).to eq(5)
+          end
+        end
+      RUBY
+    end
+
+    it "resolves against the described constant when the group has extra arguments (metadata)" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor, :aggregate_failures do
+          it "returns the const" do
+            expect(described_class::TIMEOUT).to eq(5)
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor, :aggregate_failures do
+          it "returns the const" do
+            expect(Payments::Processor::TIMEOUT).to eq(5)
+          end
+        end
+      RUBY
+    end
+
+    it "qualifies the leading scope when the described constant is itself multi-segment" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe described_class::Config::Timeout do
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe Payments::Processor::Config::Timeout do
+          end
+        end
+      RUBY
+    end
+
+    it "qualifies a reference nested inside a described_class::Const group across passes" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe described_class::Worker do
+                   ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+            it "references a constant on the inner class" do
+              expect(described_class::SETTING).to be_truthy
+                     ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          describe Payments::Processor::Worker do
+            it "references a constant on the inner class" do
+              expect(Payments::Processor::Worker::SETTING).to be_truthy
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "resolves to the nearest enclosing example group, which may be a context" do
+      expect_offense(<<~RUBY)
+        RSpec.describe Payments do
+          context Payments::Processor do
+            describe described_class::Worker do
+                     ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Payments do
+          context Payments::Processor do
+            describe Payments::Processor::Worker do
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when the described class cannot be resolved lexically" do
+    it "registers an offense but does not autocorrect" do
+      expect_offense(<<~RUBY)
+        RSpec.describe "a collaborator" do
+          it "references a constant" do
+            described_class::Foo
+            ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
+  context "when described_class is not used as a constant scope" do
+    it "ignores a bare described_class method call" do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          subject { described_class.new }
+        end
+      RUBY
+    end
+
+    it "ignores a fully-qualified constant" do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "uses a fully qualified const" do
+            expect(Payments::Processor::Worker).to be_truthy
+          end
+        end
+      RUBY
+    end
+
+    it "ignores described_class called on an explicit receiver" do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Payments::Processor do
+          it "calls described_class on another object" do
+            expect(helper.described_class::Foo).to be_nil
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/described_class_constant_reference_spec.rb
+++ b/spec/rubocop/cop/gusto/described_class_constant_reference_spec.rb
@@ -136,6 +136,52 @@ RSpec.describe RuboCop::Cop::Gusto::DescribedClassConstantReference, :config do
       RUBY
     end
 
+    it "resolves `RSpec.describe self` to the enclosing module namespace" do
+      expect_offense(<<~RUBY)
+        module Payments
+          module Processing
+            RSpec.describe self do
+              it "references a constant" do
+                expect(described_class::TIMEOUT).to eq(5)
+                       ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+              end
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module Payments
+          module Processing
+            RSpec.describe self do
+              it "references a constant" do
+                expect(Payments::Processing::TIMEOUT).to eq(5)
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "resolves `describe self` to the enclosing class namespace" do
+      expect_offense(<<~RUBY)
+        class Payments::Processor
+          describe self do
+            subject { described_class::TIMEOUT }
+                      ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Payments::Processor
+          describe self do
+            subject { Payments::Processor::TIMEOUT }
+          end
+        end
+      RUBY
+    end
+
     it "resolves to the nearest enclosing example group, which may be a context" do
       expect_offense(<<~RUBY)
         RSpec.describe Payments do
@@ -162,6 +208,19 @@ RSpec.describe RuboCop::Cop::Gusto::DescribedClassConstantReference, :config do
     it "registers an offense but does not autocorrect" do
       expect_offense(<<~RUBY)
         RSpec.describe "a collaborator" do
+          it "references a constant" do
+            described_class::Foo
+            ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it "does not autocorrect `describe self` with no enclosing namespace" do
+      expect_offense(<<~RUBY)
+        RSpec.describe self do
           it "references a constant" do
             described_class::Foo
             ^^^^^^^^^^^^^^^ Use the fully-qualified constant name instead of scoping it through `described_class`, which Sorbet cannot resolve statically.


### PR DESCRIPTION
## What

Adds `Gusto/DescribedClassConstantReference` — a cop that flags constants scoped through `described_class` (e.g. `described_class::Worker`) in specs and autocorrects them to the fully-qualified constant the enclosing example group describes. Bare `described_class` method calls (`described_class.new`) are left alone.

```ruby
# bad
RSpec.describe Payments::Processor do
  describe described_class::Worker do
  end
end

# good
RSpec.describe Payments::Processor do
  describe Payments::Processor::Worker do
  end
end
```

## Why

With rubocop-sorbet's experimental RSpec mode, Sorbet now types `described_class` — but only the **bare** form resolves statically. `described_class::Foo` is treated as a dynamic constant reference Sorbet cannot resolve (`Dynamic constant references are unsupported`, https://srb.help/5001), which blocks the spec from type-checking at all. Eliminating the `::Foo` form is what lets Sorbet statically check the (far more common) bare `described_class.…` usages — turning a class of breakage that previously only surfaced in a full CI run into a pre-commit `srb tc` error.

This cop was incubated in the zenpayroll monolith (where it cleared ~11k existing references and is enforced going forward); upstreaming here for reuse across repos.

## Details

- Department `Gusto/` (matches where net-new gusto cops live; avoids shadowing the `rubocop-sorbet`/`rubocop-rspec` namespaces this gem already configures).
- `SafeAutoCorrect: false` — the rewrite assumes the described constant is a statically-written name.
- Scoped to spec files (`Include: '**/spec/**/*'`).
- Resolves the described class from `describe SomeClass`, from `RSpec.describe self` (→ the enclosing module/class namespace, e.g. `Payments::Processing`), and through `describe`/`context`/`feature`/aliases and nested groups, against the **nearest** enclosing example group.
- A reference in the body of a `describe described_class::X` group is flagged but **not** autocorrected, so multi-pass autocorrect converges on the correctly-nested FQN rather than baking in a wrong qualification.
- A constant defined on an **ancestor** of the described class is qualified against the described class itself (runtime-correct, but Sorbet can't resolve it through the inheritance chain); the cop docs flag this for manual re-pointing.

## Testing

- New spec at 100% line + branch coverage (covers describe/context/alias/metadata groups, nested-constant + multi-segment described constants, the nested-group cross-pass case, and the no-offense cases: bare `described_class`, already-qualified constants, explicit receiver, unresolvable string-described groups).
- `bundle exec rspec` → 366 examples, 0 failures, 100% coverage.
- `bundle exec rubocop` → clean (gem self-lints with the new cop).

