### PR TITLE
feat!: add Gusto/UnreferencedLet cop (requires Ruby >= 3.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.4
+          - "3.4"
           - "4.0"
     name: "Tests: Ruby ${{ matrix.ruby }}"
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.2
-          - 3.3
           - 3.4
+          - "4.0"
     name: "Tests: Ruby ${{ matrix.ruby }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ InternalAffairs/OnSendWithoutOnCSend:
     - 'lib/rubocop/cop/gusto/rails_env.rb' # called only on a class
     - 'lib/rubocop/cop/gusto/polymorphic_type_validation.rb' # called on a class
     - 'lib/rubocop/cop/gusto/rspec_date_time_mock.rb' # would be weird to use safe navigation with allow/expect
+    - 'lib/rubocop/cop/gusto/unreferenced_let.rb' # `&.let` is not a valid let declaration
 
 # FIXME: Workaround for a false positive caused by this cop. At time of writing,
 # it does not support reading `config/default.yml` from other sources, only from

--- a/.simplecov
+++ b/.simplecov
@@ -2,6 +2,11 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 100, branch: 100
+  # Ruby 4.0's branch-coverage instrumentation reports some branches that are in fact executed
+  # (e.g. the nil-receiver path of `&.`) as uncovered -- the same code measures 100% on 3.4 but
+  # 98.8% on 4.0. Skip the minimum-coverage gate on 4.0 only: the full suite still runs there (so
+  # real test failures block), and strict 100% line + branch coverage stays enforced on every
+  # other Ruby.
+  minimum_coverage(line: 100, branch: 100) unless RUBY_VERSION.start_with?("4.0")
   add_filter "/spec/"
 end

--- a/.simplecov
+++ b/.simplecov
@@ -2,11 +2,6 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  # Ruby 4.0's branch-coverage instrumentation reports some branches that are in fact executed
-  # (e.g. the nil-receiver path of `&.`) as uncovered -- the same code measures 100% on 3.4 but
-  # 98.8% on 4.0. Skip the minimum-coverage gate on 4.0 only: the full suite still runs there (so
-  # real test failures block), and strict 100% line + branch coverage stays enforced on every
-  # other Ruby.
-  minimum_coverage(line: 100, branch: 100) unless RUBY_VERSION.start_with?("4.0")
+  minimum_coverage line: 100, branch: 100
   add_filter "/spec/"
 end

--- a/config/default.yml
+++ b/config/default.yml
@@ -138,14 +138,11 @@ Gusto/ToplevelConstants:
 
 Gusto/UnreferencedLet:
   Description: 'Removes a lazy let whose name is never referenced (its block never runs).'
-  # Opt-in: this cop deletes code and is heuristic (it cannot see references made across files via
-  # shared examples or included harnesses), so consumers enable it per-repo with their own
-  # Include/Exclude rather than having it run by default.
-  Enabled: false
+  Enabled: true
   Include:
     - '**/spec/**/*_spec.rb'
-  # Deletion is opt-in (explicit -A) rather than applied on a plain run, because cross-file
-  # references cannot be seen.
+  # Deletion is unsafe (explicit -A required, never applied on a plain run): the cop is heuristic
+  # and cannot see references made across files via shared examples or included harnesses.
   SafeAutoCorrect: false
 
 Gusto/UsePaintNotColorize:

--- a/config/default.yml
+++ b/config/default.yml
@@ -136,6 +136,18 @@ Gusto/ToplevelConstants:
     - '**/*/spec_helper.rb'
     - 'spec/support/**/*.rb'
 
+Gusto/UnreferencedLet:
+  Description: 'Removes a lazy let whose name is never referenced (its block never runs).'
+  # Opt-in: this cop deletes code and is heuristic (it cannot see references made across files via
+  # shared examples or included harnesses), so consumers enable it per-repo with their own
+  # Include/Exclude rather than having it run by default.
+  Enabled: false
+  Include:
+    - '**/spec/**/*_spec.rb'
+  # Deletion is opt-in (explicit -A) rather than applied on a plain run, because cross-file
+  # references cannot be seen.
+  SafeAutoCorrect: false
+
 Gusto/UsePaintNotColorize:
   Description: 'Use Paint instead of colorize for terminal colors.'
   SafeAutoCorrect: false

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Flags lazy `let` declarations whose name is never referenced. A lazy `let(:name) { ... }`
+      # is only evaluated when `name` is called, so an unreferenced one is dead code -- its block
+      # never runs -- and is deleted.
+      #
+      # Eager `let!` is intentionally out of scope: it runs its block before every example for its
+      # side effect even when unreferenced, so it cannot simply be deleted. Only plain `let` is
+      # handled here.
+      #
+      # Detection is file-scoped: a `let` referenced only from another file (through a shared
+      # example or an included test harness) cannot be seen, so the cop stays conservative and
+      # prefers false negatives over false positives:
+      # - a name defined more than once in the file by `let`/`let!`/`subject` (an override /
+      #   `super` chain, including a `subject` that overrides a `let` of the same name) is never
+      #   flagged;
+      # - a `let` declared lexically inside a `shared_examples` / `shared_examples_for` /
+      #   `shared_context` block is skipped (its consumers live in other files);
+      # - every `let` in a file that uses `it_behaves_like` / `it_should_behave_like` /
+      #   `include_examples` / `include_context` is skipped, because an included shared block may
+      #   reference the binding by a name we cannot follow statically;
+      # - any `let` whose name is also defined as a `let`/`subject` in a `spec/support/**` helper is
+      #   skipped, because it is almost certainly overriding a contract an included harness consumes;
+      #   and
+      # - every `let` in a file that reflectively dispatches through a name we cannot resolve
+      #   statically (e.g. `send("expected_#{type}")`) is skipped, since any `let` could be the
+      #   target.
+      # A name counts as referenced if it is called bare (`foo`) or appears as a symbol (`:foo`) or
+      # plain string (`"foo"`) literal anywhere but the let's own name argument -- covering dynamic
+      # dispatch and `:foo` entries in data tables the spec later dispatches on.
+      #
+      # Because a bare `:foo` symbol anywhere counts as a reference, commonly-named lets
+      # (`let(:user)`, `let(:company)`, `let(:id)`) are essentially never flagged -- `create(:user)`,
+      # `:name` hash keys, and the like saturate the file. This conservative bias means the cop
+      # realistically only deletes distinctively-named dead lets; it is not a complete dead-`let`
+      # finder.
+      #
+      # @example
+      #   # bad (name never referenced -- deleted, the block never runs)
+      #   let(:unused) { create(:thing) }
+      #
+      #   # good
+      #   let(:thing) { create(:thing) }
+      #   it { expect(thing).to be_present }
+      #
+      class UnreferencedLet < Base
+        extend AutoCorrector
+        include RangeHelp
+
+        DEFINITION_METHODS = %i(let let! subject).freeze
+        # Reflective dispatch methods whose target is the first argument. When that argument is not
+        # a statically-resolvable name (a `sym` or plain `str`) -- e.g. `send("expected_#{type}")` --
+        # the called name cannot be known, so the whole file is left untouched.
+        DYNAMIC_DISPATCH_METHODS = %i(send public_send __send__ try try! method public_method respond_to?).freeze
+        FRAMEWORK_LET_PATTERN = /\b(?:let!?|subject)\s*\(?\s*:([A-Za-z_]\w*[!?]?)/
+        MSG = "Remove unreferenced `let(:%{name})` -- its name is never used, so the block never runs."
+        RESTRICT_ON_SEND = %i(let).freeze
+        SHARED_CONSUMER_DSL = %i(it_behaves_like it_should_behave_like include_examples include_context).freeze
+        SHARED_DEFINITION_DSL = %i(shared_examples shared_examples_for shared_context).freeze
+        # The glob and the pathspec encode the SAME set of files two ways: `Dir.glob` (fallback) and
+        # a regexp filter over `git ls-files` output. Keep them in sync if either changes.
+        SUPPORT_FILES_GLOB = "**/spec/support/**/*.rb"
+        SUPPORT_FILES_PATHSPEC = %r{(?:\A|/)spec/support/.+\.rb\z}
+
+        # The name symbol of any definition (`let`/`let!`/`subject`) in any block form -- used to
+        # count how many times a name is defined, so override / `super` chains (including a
+        # `subject` that overrides a `let` of the same name) are never flagged.
+        # @!method definition_name(node)
+        def_node_matcher :definition_name, <<~PATTERN
+          (any_block (send nil? {#{DEFINITION_METHODS.map { ":#{it}" }.join(' ')}} (sym $_) ...) ...)
+        PATTERN
+
+        class << self
+          # Names defined as `let`/`subject` anywhere under `spec/support/**`. Computed once per
+          # process (lazily, after boot) and shared across every file the cop inspects.
+          def framework_let_names
+            @framework_let_names ||= scan_framework_let_names(support_file_paths)
+          end
+
+          # Enumerate `spec/support/**/*.rb`. Prefer `git ls-files` (reads the git index, skipping
+          # untracked trees like `node_modules`): a leading-`**` `Dir.glob` walks the entire
+          # repository and costs seconds, while reading the index costs tens of milliseconds. Fall
+          # back to `Dir.glob` when not in a git work tree or `git` is unavailable.
+          #
+          # Tradeoff: an untracked (brand-new, uncommitted) `spec/support/*.rb` override is invisible
+          # to `git ls-files`. In that narrow window its contract names are not exempted; once
+          # committed it is seen like any other support file.
+          def support_file_paths
+            git_tracked_support_files || ::Dir.glob(SUPPORT_FILES_GLOB)
+          end
+
+          def git_tracked_support_files
+            output, status = ::Open3.capture2("git", "ls-files", "-z")
+            return nil unless status.success?
+
+            output.split("\x0").grep(SUPPORT_FILES_PATHSPEC)
+          rescue ::SystemCallError
+            nil
+          end
+
+          def scan_framework_let_names(paths)
+            paths.each_with_object(Set.new) do |path, names|
+              extract_let_names(read_source(path), names)
+            end
+          end
+
+          def extract_let_names(source, names)
+            source.scan(FRAMEWORK_LET_PATTERN) { |(captured)| names << captured.to_sym }
+            names
+          end
+
+          def read_source(path)
+            return "" unless ::File.file?(path)
+
+            ::File.read(path)
+          end
+        end
+
+        def on_send(node)
+          return unless node.receiver.nil?
+
+          name_argument = node.first_argument
+          return unless name_argument&.sym_type?
+
+          block = node.block_node
+          return unless block
+
+          name = name_argument.value
+          return if exempt_from_deletion?(name, block)
+
+          add_offense(node.loc.selector, message: format(MSG, name:)) do |corrector|
+            corrector.remove(removal_range(block))
+          end
+        end
+
+        private
+
+        # A lazy `let` is exempt from deletion whenever file-scoped analysis cannot prove its name
+        # is dead: the file dispatches through a name we cannot resolve statically, it consumes
+        # shared examples, the `let` is lexically inside a shared-example definition, its name is a
+        # `spec/support/**` framework contract, it is overridden by another definition of the same
+        # name, or it is referenced somewhere in the file.
+        def exempt_from_deletion?(name, block)
+          dynamic_dispatch? ||
+            consumes_shared_examples? ||
+            within_shared_definition?(block) ||
+            self.class.framework_let_names.include?(name) ||
+            overridden?(name) ||
+            referenced?(name)
+        end
+
+        # Delete the `let` block, plus:
+        # - an immediately-preceding `sig { ... }` (so a Sorbet signature is not left dangling),
+        # - explanatory comment lines attached directly above it (so they are not orphaned), and
+        # - a single trailing blank line where removal would otherwise leave a stray/duplicate
+        #   blank -- unless the line above is a `let`/`subject`, where that blank is the required
+        #   separator after the now-final let and must stay.
+        def removal_range(node)
+          lines = processed_source.lines
+          start_line = node.source_range.first_line
+          end_line = node.source_range.last_line
+
+          sig = preceding_sig(node)
+          start_line = sig.source_range.first_line if sig
+
+          start_line -= 1 while start_line > 1 && absorbable_comment?(lines[start_line - 2])
+
+          if end_line < lines.size && blank_line?(lines[end_line]) &&
+              !(start_line > 1 && let_or_subject_line?(lines[start_line - 2]))
+            end_line += 1
+          end
+
+          buffer = processed_source.buffer
+          range_by_whole_lines(buffer.line_range(start_line).join(buffer.line_range(end_line)), include_final_newline: true)
+        end
+
+        def absorbable_comment?(source_line)
+          stripped = source_line.strip
+          stripped.start_with?("#") && !stripped.start_with?("# rubocop:")
+        end
+
+        def blank_line?(source_line)
+          source_line.strip.empty?
+        end
+
+        def let_or_subject_line?(source_line)
+          source_line.match?(/\A\s*(?:let!?|subject)\b/)
+        end
+
+        def preceding_sig(node)
+          sibling = node.left_sibling
+          return unless sibling.is_a?(::RuboCop::AST::BlockNode)
+          return unless sibling.method?(:sig)
+
+          sibling
+        end
+
+        def within_shared_definition?(node)
+          node.each_ancestor(:any_block).any? do |ancestor|
+            SHARED_DEFINITION_DSL.include?(ancestor.method_name)
+          end
+        end
+
+        def consumes_shared_examples?
+          return @consumes_shared_examples unless @consumes_shared_examples.nil?
+
+          @consumes_shared_examples = processed_source.ast.each_node(:call).any? do |send_node|
+            SHARED_CONSUMER_DSL.include?(send_node.method_name)
+          end
+        end
+
+        # True when the file reflectively dispatches through a name we cannot resolve statically --
+        # `send`/`public_send`/`method`/etc. called with anything other than a `sym` or plain `str`
+        # first argument (most commonly an interpolated string, `send("expected_#{type}")`). In
+        # that case any `let` in the file could be the dispatch target, so none are deleted.
+        def dynamic_dispatch?
+          return @dynamic_dispatch unless @dynamic_dispatch.nil?
+
+          @dynamic_dispatch = processed_source.ast.each_node(:call).any? do |send_node|
+            next false unless DYNAMIC_DISPATCH_METHODS.include?(send_node.method_name)
+
+            target = send_node.first_argument
+            target && !target.sym_type? && !target.str_type?
+          end
+        end
+
+        def overridden?(name)
+          definitions_by_name.fetch(name, 0) > 1
+        end
+
+        def definitions_by_name
+          @definitions_by_name ||= processed_source.ast.each_node(:any_block).each_with_object(Hash.new(0)) do |node, counts|
+            name = definition_name(node)
+            counts[name] += 1 if name
+          end
+        end
+
+        def referenced?(name)
+          referenced_names.include?(name)
+        end
+
+        # A name is "referenced" if it is called as a bare method (`foo`), appears as a symbol
+        # literal (`:foo`) other than the let/subject's own name argument, or appears as a plain
+        # string literal (`"foo"`). The symbol and string cases cover indirect invocation --
+        # `send(:foo)` / `send("foo")`, or a `:foo`/`"foo"` listed in a data table the spec later
+        # dispatches on -- which file-scoped analysis cannot otherwise follow. (Interpolated-string
+        # dispatch is handled separately by `dynamic_dispatch?`, which exempts the whole file.)
+        def referenced_names
+          @referenced_names ||= processed_source.ast.each_node(:sym, :str, :call).each_with_object(Set.new) do |node, names|
+            if node.sym_type?
+              names << node.value unless definition_name_argument?(node)
+            elsif node.str_type?
+              names << node.value.to_sym
+            elsif node.receiver.nil? && node.arguments.empty?
+              names << node.method_name
+            end
+          end
+        end
+
+        def definition_name_argument?(sym_node)
+          parent = sym_node.parent
+          parent.send_type? && parent.receiver.nil? && DEFINITION_METHODS.include?(parent.method_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -31,9 +31,10 @@ module RuboCop
       # - every `let` in a file that reflectively dispatches through a name we cannot resolve
       #   statically (e.g. `send("expected_#{type}")`) is skipped, since any `let` could be the
       #   target.
-      # A name counts as referenced if it is called bare (`foo`) or appears as a symbol (`:foo`) or
-      # plain string (`"foo"`) literal anywhere but the let's own name argument -- covering dynamic
-      # dispatch and `:foo` entries in data tables the spec later dispatches on.
+      # A name counts as referenced if it is called bare (`foo`), appears as a symbol (`:foo`)
+      # anywhere but the let's own name argument, or appears as an identifier-shaped token inside
+      # any string/heredoc literal -- covering dynamic dispatch, `:foo` entries in data tables the
+      # spec later dispatches on, and bindings named only inside raw SQL/GraphQL text.
       #
       # Because a bare `:foo` symbol anywhere counts as a reference, commonly-named lets
       # (`let(:user)`, `let(:company)`, `let(:id)`) are essentially never flagged -- `create(:user)`,
@@ -63,6 +64,10 @@ module RuboCop
         # the called name cannot be known, so the whole file is left untouched.
         DYNAMIC_DISPATCH_METHODS = %i(send public_send __send__ try try! method public_method respond_to?).freeze
         FRAMEWORK_LET_PATTERN = /\b(?:let!?|subject)\s*\(?\s*:([A-Za-z_]\w*[!?]?)/
+        # Identifier-shaped tokens inside a string/heredoc literal. A `let` whose name appears only
+        # inside string text -- e.g. a binding or column referenced in raw SQL/GraphQL the spec
+        # later executes -- counts as referenced, so it is not deleted.
+        IDENTIFIER_IN_STRING = /[A-Za-z_]\w*[!?]?/
         MSG = "Remove unreferenced `let(:%{name})` -- its name is never used, so the block never runs."
         RESTRICT_ON_SEND = %i(let).freeze
         SHARED_CONSUMER_DSL = %i(it_behaves_like it_should_behave_like include_examples include_context).freeze
@@ -252,17 +257,20 @@ module RuboCop
         end
 
         # A name is "referenced" if it is called as a bare method (`foo`), appears as a symbol
-        # literal (`:foo`) other than the let/subject's own name argument, or appears as a plain
-        # string literal (`"foo"`). The symbol and string cases cover indirect invocation --
-        # `send(:foo)` / `send("foo")`, or a `:foo`/`"foo"` listed in a data table the spec later
-        # dispatches on -- which file-scoped analysis cannot otherwise follow. (Interpolated-string
-        # dispatch is handled separately by `dynamic_dispatch?`, which exempts the whole file.)
+        # literal (`:foo`) other than the let/subject's own name argument, or appears as an
+        # identifier-shaped token inside any string/heredoc literal. The symbol and string cases
+        # cover indirect invocation -- `send(:foo)` / `send("foo")`, a `:foo`/`"foo"` listed in a
+        # data table the spec later dispatches on, or a binding named only inside raw SQL/GraphQL
+        # text the spec executes -- which file-scoped analysis cannot otherwise follow. (Tokenizing
+        # string bodies, rather than matching the whole string, keeps a `let` referenced only from
+        # inside a multi-word heredoc from being deleted.) Interpolated-string *dispatch* is handled
+        # separately by `dynamic_dispatch?`, which exempts the whole file.
         def referenced_names
           @referenced_names ||= processed_source.ast.each_node(:sym, :str, :call).each_with_object(Set.new) do |node, names|
             if node.sym_type?
               names << node.value unless definition_name_argument?(node)
             elsif node.str_type?
-              names << node.value.to_sym
+              node.value.scan(IDENTIFIER_IN_STRING) { |token| names << token.to_sym }
             elsif node.receiver.nil? && node.arguments.empty?
               names << node.method_name
             end

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -50,7 +50,7 @@ module RuboCop
       #   let(:thing) { create(:thing) }
       #   it { expect(thing).to be_present }
       #
-      class UnreferencedLet < Base
+      class UnreferencedLet < ::RuboCop::Cop::RSpec::Base
         extend AutoCorrector
         include RangeHelp
 
@@ -70,8 +70,6 @@ module RuboCop
         IDENTIFIER_IN_STRING = /[A-Za-z_]\w*[!?]?/
         MSG = "Remove unreferenced `let(:%{name})` -- its name is never used, so the block never runs."
         RESTRICT_ON_SEND = %i(let).freeze
-        SHARED_CONSUMER_DSL = %i(it_behaves_like it_should_behave_like include_examples include_context).freeze
-        SHARED_DEFINITION_DSL = %i(shared_examples shared_examples_for shared_context).freeze
         # The glob and the pathspec encode the SAME set of files two ways: `Dir.glob` (fallback) and
         # a regexp filter over `git ls-files` output. Keep them in sync if either changes.
         SUPPORT_FILES_GLOB = "**/spec/support/**/*.rb"
@@ -213,17 +211,13 @@ module RuboCop
         end
 
         def within_shared_definition?(node)
-          node.each_ancestor(:any_block).any? do |ancestor|
-            SHARED_DEFINITION_DSL.include?(ancestor.method_name)
-          end
+          node.each_ancestor(:any_block).any? { |ancestor| shared_group?(ancestor) }
         end
 
         def consumes_shared_examples?
           return @consumes_shared_examples unless @consumes_shared_examples.nil?
 
-          @consumes_shared_examples = processed_source.ast.each_node(:call).any? do |send_node|
-            SHARED_CONSUMER_DSL.include?(send_node.method_name)
-          end
+          @consumes_shared_examples = processed_source.ast.each_node(:call).any? { |send_node| include?(send_node) }
         end
 
         # True when the file reflectively dispatches through a name we cannot resolve statically --

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -264,7 +264,9 @@ module RuboCop
             if node.sym_type?
               names << node.value unless definition_name_argument?(node)
             elsif node.str_type?
-              node.value.scan(IDENTIFIER_IN_STRING) { |token| names << token.to_sym }
+              # A string with invalid encoding (e.g. a deliberate bad-UTF-8 test fixture) cannot
+              # contain an identifier-shaped reference and would raise on `scan`, so skip it.
+              node.value.scan(IDENTIFIER_IN_STRING) { |token| names << token.to_sym } if node.value.valid_encoding?
             elsif node.receiver.nil? && node.arguments.empty?
               names << node.method_name
             end

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -26,7 +26,8 @@ module RuboCop
       #   reference the binding by a name we cannot follow statically;
       # - any `let` whose name is also defined as a `let`/`subject` in a `spec/support/**` helper is
       #   skipped, because it is almost certainly overriding a contract an included harness consumes;
-      #   and
+      # - `let(:cop_config)` is skipped: it is a rubocop-rspec contract consumed by the `:config`
+      #   shared context, not by a reference in the spec file; and
       # - every `let` in a file that reflectively dispatches through a name we cannot resolve
       #   statically (e.g. `send("expected_#{type}")`) is skipped, since any `let` could be the
       #   target.
@@ -53,6 +54,10 @@ module RuboCop
         include RangeHelp
 
         DEFINITION_METHODS = %i(let let! subject).freeze
+        # `let`s consumed by a test framework rather than by a reference in the spec file. The
+        # rubocop-rspec `:config` shared context reads `cop_config`, so it is live even though the
+        # spec never names it.
+        FRAMEWORK_RESERVED_NAMES = %i(cop_config).freeze
         # Reflective dispatch methods whose target is the first argument. When that argument is not
         # a statically-resolvable name (a `sym` or plain `str`) -- e.g. `send("expected_#{type}")` --
         # the called name cannot be known, so the whole file is left untouched.
@@ -141,12 +146,14 @@ module RuboCop
         private
 
         # A lazy `let` is exempt from deletion whenever file-scoped analysis cannot prove its name
-        # is dead: the file dispatches through a name we cannot resolve statically, it consumes
-        # shared examples, the `let` is lexically inside a shared-example definition, its name is a
-        # `spec/support/**` framework contract, it is overridden by another definition of the same
-        # name, or it is referenced somewhere in the file.
+        # is dead: its name is a framework-reserved contract (e.g. `cop_config`), the file
+        # dispatches through a name we cannot resolve statically, it consumes shared examples, the
+        # `let` is lexically inside a shared-example definition, its name is a `spec/support/**`
+        # framework contract, it is overridden by another definition of the same name, or it is
+        # referenced somewhere in the file.
         def exempt_from_deletion?(name, block)
-          dynamic_dispatch? ||
+          FRAMEWORK_RESERVED_NAMES.include?(name) ||
+            dynamic_dispatch? ||
             consumes_shared_examples? ||
             within_shared_definition?(block) ||
             self.class.framework_let_names.include?(name) ||

--- a/rubocop-gusto.gemspec
+++ b/rubocop-gusto.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/gusto/rubocop-gusto"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.4"
 
   if spec.respond_to?(:metadata)
     # spec.metadata['allowed_push_host'] = 'https://rubygems.org'

--- a/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
+++ b/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
@@ -142,6 +142,16 @@ RSpec.describe RuboCop::Cop::Gusto::UnreferencedLet, :config do
     RUBY
   end
 
+  it "does not flag `let(:cop_config)` (a rubocop-rspec framework contract)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe RuboCop::Cop::Gusto::SomeCop, :config do
+        let(:cop_config) { { "Enabled" => true } }
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
   it "does not flag a let referenced via dynamic dispatch" do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Thing do

--- a/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
+++ b/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
@@ -1,0 +1,403 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe RuboCop::Cop::Gusto::UnreferencedLet, :config do
+  # Keep the file-detection examples independent of whatever `spec/support/**` happens to exist
+  # in the working directory; the framework-contract behavior is exercised explicitly below.
+  before { described_class.instance_variable_set(:@framework_let_names, Set.new) }
+
+  it "flags and removes unreferenced lazy lets" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused) { create(:thing) }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+        let(:also_unused) { create(:other) }
+        ^^^ Remove unreferenced `let(:also_unused)` -- its name is never used, so the block never runs.
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "removes a preceding Sorbet signature along with the let" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        sig { returns(Integer) }
+        let(:unused) { 1 }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "flags an unreferenced let written as a numbered-parameter block" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused) { create(_1) }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+      end
+    RUBY
+  end
+
+  it "removes an explanatory comment attached directly above the let" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:kept) { 1 }
+
+        # allows us to see the output
+        let(:unused) { false }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        it { expect(kept).to eq(1) }
+      end
+    RUBY
+
+    # The comment + let are removed, and the now-duplicate trailing blank is consumed so no
+    # stray blank is left behind.
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        let(:kept) { 1 }
+
+        it { expect(kept).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "consumes a trailing blank at a block-body edge but keeps the blank after a final let" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:kept) { 1 }
+        let(:unused) { 2 }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        it { expect(kept).to eq(1) }
+      end
+    RUBY
+
+    # `let(:kept)` precedes the removal, so the blank after it (the final-let separator) stays.
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        let(:kept) { 1 }
+
+        it { expect(kept).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "does not absorb a rubocop directive comment above the let" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        # rubocop:disable Style/Something
+        let(:unused) { false }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+        # rubocop:enable Style/Something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        # rubocop:disable Style/Something
+        # rubocop:enable Style/Something
+      end
+    RUBY
+  end
+
+  it "does not flag an eager let! (out of scope)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let!(:unused) { create(:thing) }
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "does not flag a referenced lazy let" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:thing) { create(:thing) }
+
+        it { expect(thing).to be_present }
+      end
+    RUBY
+  end
+
+  it "does not flag a let referenced via dynamic dispatch" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:thing) { create(:thing) }
+
+        it { expect(send(:thing)).to be_present }
+      end
+    RUBY
+  end
+
+  it "does not flag a let referenced only as a symbol literal (data-table dispatch)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:special_tax) { build(:tax) }
+
+        it "dispatches by name" do
+          [[:special_tax, :pending]].each do |name, _state|
+            expect(send(name)).to be_present
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "does not flag a let referenced only as a string literal (string dispatch)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:special_tax) { build(:tax) }
+
+        it { expect(send("special_tax")).to be_present }
+      end
+    RUBY
+  end
+
+  it "skips every let in a file that dispatches through an interpolated string" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:expected_dental_value) { 1 }
+
+        it "dispatches by interpolated name" do
+          %w(dental vision).each do |type|
+            expect(described_class.for(type)).to eq(send("expected_\#{type}_value"))
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "still flags a dead let in a file whose only send target is a static string" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused) { create(:thing) }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        it { expect(send("other")).to be_present }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        it { expect(send("other")).to be_present }
+      end
+    RUBY
+  end
+
+  it "does not flag a name defined by more than one let/let! (override / super chain)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:value) { 1 }
+
+        context "nested" do
+          let!(:value) { 2 }
+
+          it { expect(1).to eq(1) }
+        end
+      end
+    RUBY
+  end
+
+  it "does not flag a let overridden by a subject of the same name (super chain)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:described) { build(:thing) }
+
+        context "when active" do
+          subject(:described) { super().tap(&:activate) }
+
+          it { is_expected.to be_active }
+        end
+      end
+    RUBY
+  end
+
+  it "does not flag an unreferenced subject (only lazy let is in scope)" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        subject(:unused) { build(:thing) }
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "skips every let in a file that consumes shared examples" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused) { create(:thing) }
+
+        it_behaves_like "a thing"
+      end
+    RUBY
+  end
+
+  it "skips a let declared inside a shared example definition" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.shared_examples "a thing" do
+        let(:unused_inner) { create(:thing) }
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
+  it "still flags an unreferenced let declared outside a shared example definition" do
+    expect_offense(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused) { create(:thing) }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        shared_examples "a thing" do
+          it { expect(1).to eq(1) }
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Thing do
+        shared_examples "a thing" do
+          it { expect(1).to eq(1) }
+        end
+      end
+    RUBY
+  end
+
+  it "ignores let declarations without a symbol name" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        name = :dynamic
+        let(name) { create(:thing) }
+        let { create(:thing) }
+      end
+    RUBY
+  end
+
+  it "ignores a let call with no block" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:unused)
+      end
+    RUBY
+  end
+
+  it "ignores a let-like call with an explicit receiver" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        config.let(:unused) { create(:thing) }
+      end
+    RUBY
+  end
+
+  it "does not flag a let that overrides a framework contract defined in spec/support" do
+    described_class.instance_variable_set(:@framework_let_names, Set[:query])
+
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing, subgraph: :foo do
+        let(:query) { "mutation { ... }" }
+
+        it { is_expected.to be_present }
+      end
+    RUBY
+  end
+
+  describe "framework let-name discovery" do
+    it "memoizes the scanned name set" do
+      described_class.instance_variable_set(:@framework_let_names, nil)
+
+      first = described_class.framework_let_names
+      second = described_class.framework_let_names
+
+      expect(first).to be_a(Set).and equal(second)
+    end
+
+    it "extracts let, let! and subject names from source" do
+      names = described_class.extract_let_names(<<~RUBY, Set.new)
+        let(:foo) { 1 }
+        let! :bar do
+          2
+        end
+        subject(:baz) { 3 }
+        plain_method(:not_a_let)
+      RUBY
+
+      expect(names).to contain_exactly(:foo, :bar, :baz)
+    end
+
+    it "scans paths for let names, tolerating unreadable files" do
+      file = Tempfile.new(["support", ".rb"])
+      file.write("let(:harness_thing) { 1 }")
+      file.close
+
+      names = described_class.scan_framework_let_names([file.path, "/no/such/support/file.rb"])
+
+      expect(names).to contain_exactly(:harness_thing)
+    ensure
+      file&.close!
+    end
+
+    it "returns an empty string when a file cannot be read" do
+      expect(described_class.read_source("/no/such/support/file.rb")).to eq("")
+    end
+  end
+
+  describe "support-file enumeration" do
+    it "selects spec/support .rb paths from the git index" do
+      status = instance_double(Process::Status, success?: true)
+      output = ["packs/a/spec/support/helper.rb", "lib/y.rb", "spec/support/root.rb", "spec/supportive/no.rb", ""].join("\x0")
+      allow(Open3).to receive(:capture2).with("git", "ls-files", "-z").and_return([output, status])
+
+      expect(described_class.git_tracked_support_files)
+        .to contain_exactly("packs/a/spec/support/helper.rb", "spec/support/root.rb")
+    end
+
+    it "returns nil when git ls-files exits non-zero" do
+      status = instance_double(Process::Status, success?: false)
+      allow(Open3).to receive(:capture2).and_return(["", status])
+
+      expect(described_class.git_tracked_support_files).to be_nil
+    end
+
+    it "returns nil when git is unavailable" do
+      allow(Open3).to receive(:capture2).and_raise(Errno::ENOENT)
+
+      expect(described_class.git_tracked_support_files).to be_nil
+    end
+
+    it "uses the git-tracked files when available" do
+      allow(described_class).to receive(:git_tracked_support_files).and_return(["spec/support/tracked.rb"])
+
+      expect(described_class.support_file_paths).to eq(["spec/support/tracked.rb"])
+    end
+
+    it "falls back to Dir.glob when git tracking is unavailable" do
+      allow(described_class).to receive(:git_tracked_support_files).and_return(nil)
+      allow(Dir).to receive(:glob).with(described_class::SUPPORT_FILES_GLOB).and_return(["spec/support/from_glob.rb"])
+
+      expect(described_class.support_file_paths).to eq(["spec/support/from_glob.rb"])
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
+++ b/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
@@ -232,6 +232,23 @@ RSpec.describe RuboCop::Cop::Gusto::UnreferencedLet, :config do
     RUBY
   end
 
+  it "does not crash on a let whose block contains an invalid-UTF-8 string literal" do
+    expect_offense(<<~'RUBY')
+      RSpec.describe Thing do
+        let(:unused) { String.new("\xc2invalid", encoding: "UTF-8") }
+        ^^^ Remove unreferenced `let(:unused)` -- its name is never used, so the block never runs.
+
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      RSpec.describe Thing do
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+  end
+
   it "does not flag a name defined by more than one let/let! (override / super chain)" do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Thing do

--- a/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
+++ b/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
@@ -186,6 +186,21 @@ RSpec.describe RuboCop::Cop::Gusto::UnreferencedLet, :config do
     RUBY
   end
 
+  it "does not flag a let referenced only inside a heredoc body" do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Thing do
+        let(:cutoff_date) { Date.today }
+        let(:query) do
+          <<~SQL
+            SELECT * FROM things WHERE created_at < cutoff_date
+          SQL
+        end
+
+        it { expect(described_class.run(query)).to be_present }
+      end
+    RUBY
+  end
+
   it "skips every let in a file that dispatches through an interpolated string" do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Thing do

--- a/spec/rubocop/gusto/config_yml_spec.rb
+++ b/spec/rubocop/gusto/config_yml_spec.rb
@@ -431,4 +431,34 @@ RSpec.describe RuboCop::Gusto::ConfigYml do
       YAML
     end
   end
+
+  describe "#sort! with chunks that have no resolvable key name" do
+    it "sorts a trailing comment-only chunk (no key) to the end" do
+      config = described_class.new(<<~YAML.lines)
+        plugins:
+          - rubocop-gusto
+
+        # a trailing comment chunk with no key of its own
+      YAML
+
+      # The comment chunk has no key, so it sorts after the keyed preamble.
+      expect(config.sort!.to_s).to eq(<<~YAML)
+        plugins:
+          - rubocop-gusto
+
+        # a trailing comment chunk with no key of its own
+      YAML
+    end
+
+    it "handles a chunk whose first line is not a key (no colon)" do
+      config = described_class.new(<<~YAML.lines)
+        plugins:
+          - rubocop-gusto
+
+        notakey
+      YAML
+
+      expect { config.sort! }.not_to raise_error
+    end
+  end
 end

--- a/spec/rubocop/gusto_spec.rb
+++ b/spec/rubocop/gusto_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe RuboCop::Gusto do
       registry.with_department(:Gusto).cops.map(&:cop_name)
     end
 
-    let(:configuration_keys) { config.keys }
-
-    let(:version_regexp) { /\A\d+\.\d+\z|\A<<next>>\z/ }
-
     it "includes all gusto cops in the configuration" do
       missing_cops = cop_names - config.keys
       expect(missing_cops).to be_empty, "Cops not found in config/default.yml: #{missing_cops.inspect}"


### PR DESCRIPTION
## What

Adds `Gusto/UnreferencedLet`: a cop that flags lazy `let(:name) { ... }` declarations whose name is never referenced in the file. A lazy `let` only runs when its name is called, so an unreferenced one is dead code — the block never runs — and is removed on `-A`.

This reconciles the two existing copies of this cop — `Gusto/zenpayroll` (`components/custom_cops/.../zenpayroll/unreferenced_let.rb`, PRs [#344838](https://github.com/Gusto/zenpayroll/pull/344838) / [#345011](https://github.com/Gusto/zenpayroll/pull/345011)) and `Gusto/hawaiian-ice` — into a single canonical implementation in the shared gem.

## Why

The cop was independently carried in two repos. Upstreaming it removes the duplication and lets any consumer opt in. The hawaiian-ice rollout also surfaced a false-positive class the original zenpayroll version didn't handle, which is fixed here (see below), so the upstreamed version is strictly more correct than either source.

## Behavior

Conservative by design — it can't see cross-file references, so it prefers false negatives:
- eager `let!` is out of scope (its block runs for side effects even when unreferenced);
- a name defined more than once (override / `super` chain, incl. a `subject` overriding a `let`) is never flagged;
- lets inside `shared_examples`/`shared_context`, and every let in a file that consumes shared examples (`it_behaves_like`/`include_context`/…), are skipped;
- names also defined as a `let`/`subject` under `spec/support/**` (framework contracts) are skipped;
- **files that reflectively dispatch through a name that can't be resolved statically — e.g. `send("expected_#{type}")` — are skipped wholesale.** *(This `dynamic_dispatch?` guard and treating string literals as references are additions beyond the original zenpayroll cop, added after a hawaiian-ice CI run flagged an interpolated-dispatch false positive.)*

A name counts as referenced if called bare (`foo`), or appearing as a `:symbol` literal, or as an identifier-shaped token inside any `"string"`/heredoc literal — the last covers a binding referenced only inside raw SQL/GraphQL text the spec later executes (string bodies are tokenized rather than matched whole, so a name inside a multi-word heredoc keeps its `let` alive).

## Config

Shipped **`Enabled: true`** with **`SafeAutoCorrect: false`** and an `Include` of `**/spec/**/*_spec.rb`. Because `SafeAutoCorrect` is off, a normal run only **reports** — deletion requires an explicit `-A`, never a plain `--autocorrect`. The `let(:cop_config)` rubocop-rspec contract (consumed by the `:config` shared context via metadata rather than an explicit reference) is exempted by name via `FRAMEWORK_RESERVED_NAMES`, so consumers' own RuboCop cop specs are not flagged. Consumers still tune scope per-repo with their own `Include`/`Exclude` (as zenpayroll and hawaiian-ice do).

## Breaking change — Ruby >= 3.4

The `definition_name` matcher derives its node pattern from `DEFINITION_METHODS` using the `it` implicit block parameter (Ruby 3.4+), so the gem now requires Ruby >= 3.4. **This drops support for consumers on Ruby 3.2 and 3.3.** The CI matrix is updated to test Ruby 3.4 and 4.0.

## Tests

- `spec/rubocop/cop/gusto/unreferenced_let_spec.rb` — 34 examples covering the conservative exemptions, removal of trailing `sig`/comments/blank lines, numbered-parameter blocks, the dynamic-dispatch / string-literal / heredoc-body cases, framework-contract discovery, and `git ls-files` support-file enumeration.
- Full suite: **390 examples, 0 failures, 100% line + branch coverage**; `bundle exec rubocop` clean across the gem.
