### PR TITLE
docs: add source doc comments and @example blocks to 8 undocumented cops

### DIFF
--- a/lib/rubocop/cop/gusto/bootsnap_load_file.rb
+++ b/lib/rubocop/cop/gusto/bootsnap_load_file.rb
@@ -3,7 +3,17 @@
 module RuboCop
   module Cop
     module Gusto
-      # Do not use Bootsnap to load files. Use `require` instead.
+      # Prefer `YAML.load_file`/`JSON.load_file` over reading a file and then
+      # parsing its contents. Bootsnap caches the parsed result of `load_file`,
+      # so this improves load time.
+      #
+      # @example
+      #   # bad
+      #   YAML.load(File.read("config.yml"))
+      #   File.open("config.yml") { |f| YAML.load(f) }
+      #
+      #   # good
+      #   YAML.load_file("config.yml")
       class BootsnapLoadFile < Base
         PROHIBITED_CONSTANTS = Set[:YAML, :JSON].freeze
         RESTRICT_ON_SEND = %i(load).freeze

--- a/lib/rubocop/cop/gusto/datadog_constant.rb
+++ b/lib/rubocop/cop/gusto/datadog_constant.rb
@@ -3,6 +3,16 @@
 module RuboCop
   module Cop
     module Gusto
+      # Disallow referencing the `Datadog` constant directly. Calls should go
+      # through an approved wrapper library so instrumentation stays consistent
+      # and swappable.
+      #
+      # @example
+      #   # bad
+      #   Datadog::Tracing.active_trace
+      #
+      #   # good
+      #   Observability.active_trace
       class DatadogConstant < Base
         MSG = "Do not call Datadog directly, use an appropriate wrapper library."
         NAMESPACE = "Datadog"

--- a/lib/rubocop/cop/gusto/discouraged_gem.rb
+++ b/lib/rubocop/cop/gusto/discouraged_gem.rb
@@ -3,13 +3,16 @@
 module RuboCop
   module Cop
     module Gusto
-      # Flags installation of discouraged gems (e.g., timecop) in Gemfiles and gemspecs.
+      # Flag installation of discouraged gems (e.g. timecop) in Gemfiles and
+      # gemspecs. The discouraged gems and their advice are configured under
+      # `Gems:`; intended to be enabled in Rails projects via config/rails.yml.
       #
-      # Configuration:
-      #   Gems:
-      #     timecop: "Use Rails' time helpers (e.g., freeze_time, travel_to) instead of Timecop."
+      # @example Gems: { timecop: "Use Rails' time helpers instead of Timecop." }
+      #   # bad
+      #   gem "timecop"
       #
-      # This cop is intended to be enabled in Rails projects via config/rails.yml.
+      #   # good
+      #   # Use Rails' time helpers (freeze_time, travel_to) instead.
       class DiscouragedGem < Base
         MSG = "Avoid using the '%{gem}' gem. %{advice}"
 

--- a/lib/rubocop/cop/gusto/discouraged_gem.rb
+++ b/lib/rubocop/cop/gusto/discouraged_gem.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Gusto
       # Flag installation of discouraged gems (e.g. timecop) in Gemfiles and
-      # gemspecs. The discouraged gems and their advice are configured under
+      # gemspecs. The discouraged gems an advice about alternatives are configured under
       # `Gems:`; intended to be enabled in Rails projects via config/rails.yml.
       #
       # @example Gems: { timecop: "Use Rails' time helpers instead of Timecop." }

--- a/lib/rubocop/cop/gusto/execute_migration.rb
+++ b/lib/rubocop/cop/gusto/execute_migration.rb
@@ -3,6 +3,20 @@
 module RuboCop
   module Cop
     module Gusto
+      # Disallow `execute` (raw SQL) in migrations. Run raw SQL from a backfill
+      # rake task, or pass SQL options to `add_column`/`change_column` instead,
+      # so migrations stay reversible and schema-focused.
+      #
+      # @example
+      #   # bad
+      #   def up
+      #     execute("UPDATE users SET active = true")
+      #   end
+      #
+      #   # good
+      #   def up
+      #     add_column :users, :active, :boolean, default: true
+      #   end
       class ExecuteMigration < Base
         MSG = "Do not use `execute` to run raw SQL in a migration. Run the query from a backfill rake task or pass the SQL options to the `add_column`/`change_column` method."
         RESTRICT_ON_SEND = [:execute].freeze

--- a/lib/rubocop/cop/gusto/factory_classes_or_modules.rb
+++ b/lib/rubocop/cop/gusto/factory_classes_or_modules.rb
@@ -3,6 +3,24 @@
 module RuboCop
   module Cop
     module Gusto
+      # Disallow defining classes or modules in factory directories. They break
+      # Rails autoloading/reloading; define shared helpers outside the factories.
+      #
+      # @example
+      #   # bad
+      #   # spec/factories/users.rb
+      #   class UserHelper
+      #   end
+      #
+      #   FactoryBot.define do
+      #     factory :user
+      #   end
+      #
+      #   # good
+      #   # spec/factories/users.rb
+      #   FactoryBot.define do
+      #     factory :user
+      #   end
       class FactoryClassesOrModules < Base
         MSG = "Do not define modules or classes in factory directories - they break reloading"
 

--- a/lib/rubocop/cop/gusto/paperclip_or_attachable.rb
+++ b/lib/rubocop/cop/gusto/paperclip_or_attachable.rb
@@ -4,6 +4,15 @@
 module RuboCop
   module Cop
     module Gusto
+      # Disallow new Paperclip / Attachable attachments. New attachments should
+      # use ActiveStorage instead.
+      #
+      # @example
+      #   # bad
+      #   has_attached_file :avatar
+      #
+      #   # good
+      #   has_one_attached :avatar
       class PaperclipOrAttachable < Base
         MSG = "No more new paperclip or Attachable are allowed. New attachments should use ActiveStorage instead"
         RESTRICT_ON_SEND = %i(has_attached_file has_pdf_attachment has_attachment).freeze

--- a/lib/rubocop/cop/gusto/polymorphic_type_validation.rb
+++ b/lib/rubocop/cop/gusto/polymorphic_type_validation.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
-# This cop enforces that polymorphic relations have a corresponding validation
-# for their type field with an inclusion validation. This is required in order for Tapioca
-# to generate correct Sorbet types
 module RuboCop
   module Cop
     module Gusto
+      # Require polymorphic relations to validate their `*_type` field with an
+      # inclusion validation (or `polymorphic_methods_for`). This is needed for
+      # Tapioca to generate correct Sorbet types.
+      #
+      # @example
+      #   # bad
+      #   belongs_to :subscription_detail, polymorphic: true
+      #
+      #   # good
+      #   VALID_TYPES = T.let([Foo.polymorphic_name, Bar.polymorphic_name].freeze, T::Array[String])
+      #   belongs_to :subscription_detail, polymorphic: true
+      #   validates :subscription_detail_type, presence: true, inclusion: { in: VALID_TYPES }
+      #
+      #   # also good
+      #   include PolymorphicCallable
+      #   VALID_TYPES = T.let([Foo.polymorphic_name, Bar.polymorphic_name].freeze, T::Array[String])
+      #   belongs_to :subscription_detail, polymorphic: true
+      #   polymorphic_methods_for :subscription_detail, VALID_TYPES
       class PolymorphicTypeValidation < Base
         RESTRICT_ON_SEND = %i(belongs_to validates polymorphic_methods_for).freeze
 

--- a/lib/rubocop/cop/gusto/sidekiq_params.rb
+++ b/lib/rubocop/cop/gusto/sidekiq_params.rb
@@ -3,6 +3,18 @@
 module RuboCop
   module Cop
     module Gusto
+      # Disallow keyword arguments on Sidekiq `perform` methods. Sidekiq
+      # serializes job arguments as JSON and replays them positionally, so
+      # keyword arguments are not preserved.
+      #
+      # @example
+      #   # bad
+      #   def perform(user_id:, force: false)
+      #   end
+      #
+      #   # good
+      #   def perform(user_id, force = false)
+      #   end
       class SidekiqParams < Base
         MSG = "Sidekiq perform methods cannot take keyword arguments"
 


### PR DESCRIPTION
## What

Adds the source-level class doc comment + `@example` (bad/good) block to the 8 Gusto cops that were missing them, so every cop documents an inline example like the rest of the suite already does:

- `Gusto/BootsnapLoadFile`
- `Gusto/DatadogConstant`
- `Gusto/DiscouragedGem`
- `Gusto/ExecuteMigration`
- `Gusto/FactoryClassesOrModules`
- `Gusto/PaperclipOrAttachable`
- `Gusto/PolymorphicTypeValidation`
- `Gusto/SidekiqParams`

## Why

`spec/rubocop/gusto_spec.rb` already enforces a `Description` in `config/default.yml` for every cop, but nothing enforced the RuboCop-idiomatic **source** doc comment + `@example`. ~14 cops had them; these 8 didn't. This brings the suite to a consistent bar.

Two small accuracy fixes along the way:
- `BootsnapLoadFile`'s one-line comment said "Use `require` instead", which doesn't match what the cop does — it flags read-then-parse (`YAML.load(File.read(...))`) and recommends `YAML.load_file`. Rewritten to match.
- `PolymorphicTypeValidation` had a comment above `module RuboCop` (not the cop); moved it into a proper class doc comment with `@example`.

## Verification

- `bundle exec rspec` → **354 examples, 0 failures; 100% line + 100% branch coverage**
- `bundle exec rubocop` on all 8 files → **no offenses**

Documentation only — no cop logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)