### PR TITLE
fix: exclude .buildkite directories from AllCops in shared config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,8 @@ AllCops:
   DisplayCopNames: true
   NewCops: disable
   SuggestExtensions: false
+  Exclude:
+    - '**/.buildkite/**/*'
 
 Bundler/OrderedGems:
   ConsiderPunctuation: true


### PR DESCRIPTION
## What

`rubocop-gusto` v11.0.0 removed the blanket `./.[!.]*/**/*` dot-directory exclusion from `AllCops` in `config/default.yml`. This was the right call — it restores pre-commit rubocop coverage inside Claude worktrees (which live under `.claude/`, a dot directory).

However, nothing replaced the `.buildkite/**/*` exclusion that was previously implied by the blanket pattern. This PR adds an explicit `**/.buildkite/**/*` exclusion so consuming repos don't accidentally lint Buildkite pipeline Ruby files, which are infrastructure config rather than application code.

Using `**/.buildkite/**/*` instead of `.buildkite/**/*` covers repos (like `hawaiian-ice`) that have embedded gem-level `.buildkite/` directories.

## Related

- ZP fix: https://github.com/Gusto/zenpayroll/pull/324006
- Jira: https://gustohq.atlassian.net/browse/RR-708

🤖 Generated with [Claude Code](https://claude.com/claude-code)