### PR TITLE
fix: use UTF-8 encoding when reading support files in UnreferencedLet

### DIFF
--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -126,7 +126,7 @@ module RuboCop
           def read_source(path)
             return "" unless ::File.file?(path)
 
-            ::File.read(path)
+            ::File.read(path, encoding: "UTF-8")
           end
         end
 


### PR DESCRIPTION
## What

`File.read(path)` without an explicit encoding defaults to `Encoding.default_external`, which is US-ASCII on macOS. When the `Gusto/UnreferencedLet` cop scans `spec/support/**/*.rb` files to collect framework-defined let names, any support file containing non-ASCII characters (e.g. emoji) causes `String#scan` to raise:

```
ArgumentError: invalid byte sequence in US-ASCII
```

## Fix

Pass `encoding: "UTF-8"` explicitly to `File.read` in `read_source`, matching how the equivalent `HawaiianIce/UnreferencedLet` cop in `hawaiian-ice` already handles this (fixed in hawaiian-ice PR #53908).

## Why this wasn't caught earlier

The crash only manifests on macOS where `Encoding.default_external` is US-ASCII. Linux CI environments default to UTF-8, so the cop works fine there. The issue was reported after `rubocop-gusto 11.0.0` was bumped in hawaiian-ice (PR #54211), which introduced `Gusto/UnreferencedLet` for the first time.

## Related

- hawaiian-ice PR that applied the same fix to the local cop: [Gusto/hawaiian-ice#53908](https://github.com/Gusto/hawaiian-ice/pull/53908)
- Upstream PR that added `Gusto/UnreferencedLet`: [#128](https://github.com/Gusto/rubocop-gusto/pull/128)