### PR TITLE
feat: add Gusto/PluckOnSelect cop

### DIFF
--- a/config/gusto_cops.yml
+++ b/config/gusto_cops.yml
@@ -67,6 +67,9 @@ Gusto/PerformClassMethod:
   WorkerModules:
     - Sidekiq::Worker
 
+Gusto/PluckOnSelect:
+  Description: "Do not use `.pluck` on `.select`. Use one or the other."
+
 Gusto/PolymorphicTypeValidation:
   Description: 'Ensures that polymorphic relations include a type validation, which is necessary for generating Sorbet types.'
   Include:

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -18,6 +18,9 @@ Gusto/DiscouragedGem:
   Gems:
     timecop: "Use Rails' time helpers (e.g., freeze_time, travel_to) instead of Timecop."
 
+Gusto/PluckOnSelect:
+  Description: "Do not use `.pluck` on `.select`. Use one or the other."
+
 Performance/DoubleStartEndWith:
   IncludeActiveSupportAliases: true
 

--- a/lib/rubocop/cop/gusto/pluck_on_select.rb
+++ b/lib/rubocop/cop/gusto/pluck_on_select.rb
@@ -17,17 +17,17 @@ module RuboCop
       #   # good
       #   User.pluck(:id)
       #
-      # @example Column alias — .pluck raises "Unknown column" because it ignores the alias
+      # @example Column alias: .pluck raises "Unknown column" because it ignores the alias
       #   # bad
       #   User.select('id AS id2').pluck('id2')
       #
-      #   # good — use .select alone if you need the alias
+      #   # good: use .select alone if you need the alias
       #   User.select(:id, 'id AS id2')
       #
-      #   # good — use .pluck alone if you don't need the alias
+      #   # good: use .pluck alone if you don't need the alias
       #   User.pluck(:id)
       #
-      # @example DISTINCT — .pluck loads all rows, ignoring the DISTINCT from .select
+      # @example DISTINCT: .pluck loads all rows, ignoring the DISTINCT from .select
       #   # bad
       #   User.select('DISTINCT email').pluck(:email)
       #
@@ -35,7 +35,7 @@ module RuboCop
       #   User.distinct.pluck(:email)
       #
       class PluckOnSelect < Base
-        RESTRICT_ON_SEND = %i[pluck].freeze
+        RESTRICT_ON_SEND = %i(pluck).freeze
         MSG = "Do not use `.pluck` on `.select`."
 
         def on_send(node)

--- a/lib/rubocop/cop/gusto/pluck_on_select.rb
+++ b/lib/rubocop/cop/gusto/pluck_on_select.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Do not use `.pluck` on `.select`.
+      #
+      # `.select` returns an ActiveRecord relation with only the selected columns marked for
+      # retrieval. `.pluck` returns an array of column values. When chained, `.pluck` is unaware
+      # of any directive passed to `.select` (e.g. column aliases or a DISTINCT clause), which
+      # can cause unexpected behavior.
+      #
+      # @example Redundant select
+      #   # bad
+      #   User.select(:id).pluck(:id)
+      #
+      #   # good
+      #   User.pluck(:id)
+      #
+      # @example Column alias — .pluck raises "Unknown column" because it ignores the alias
+      #   # bad
+      #   User.select('id AS id2').pluck('id2')
+      #
+      #   # good — use .select alone if you need the alias
+      #   User.select(:id, 'id AS id2')
+      #
+      #   # good — use .pluck alone if you don't need the alias
+      #   User.pluck(:id)
+      #
+      # @example DISTINCT — .pluck loads all rows, ignoring the DISTINCT from .select
+      #   # bad
+      #   User.select('DISTINCT email').pluck(:email)
+      #
+      #   # good
+      #   User.distinct.pluck(:email)
+      #
+      class PluckOnSelect < Base
+        RESTRICT_ON_SEND = %i[pluck].freeze
+        MSG = "Do not use `.pluck` on `.select`."
+
+        def on_send(node)
+          return unless node.receiver
+
+          receiver_node = node.receiver
+          while receiver_node
+            if receiver_node.call_type? && receiver_node.method?(:select)
+              add_offense(node)
+              break
+            end
+            receiver_node = receiver_node.receiver
+          end
+        end
+        alias_method :on_csend, :on_send
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/pluck_on_select_spec.rb
+++ b/spec/rubocop/cop/gusto/pluck_on_select_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gusto::PluckOnSelect, :config do
+  it "registers an offense for pluck on select" do
+    expect_offense(<<~RUBY)
+      User.select(:id).pluck(:id)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense for pluck on select with a string column" do
+    expect_offense(<<~RUBY)
+      User.select('id').pluck(:id)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense for pluck on select with a column alias" do
+    expect_offense(<<~RUBY)
+      User.select('id AS id2').pluck('id2')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense for pluck on select with DISTINCT" do
+    expect_offense(<<~RUBY)
+      User.select('DISTINCT id').pluck(:id)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense when select is higher up in the receiver chain" do
+    expect_offense(<<~RUBY)
+      User.select('id AS id2').distinct.pluck(:id2)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense for pluck on select with a block filter" do
+    expect_offense(<<~RUBY)
+      User.select(&:active?).pluck(:id)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "registers an offense for pluck on select using safe navigation" do
+    expect_offense(<<~RUBY)
+      User&.select(:id)&.pluck(:id)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use `.pluck` on `.select`.
+    RUBY
+  end
+
+  it "does not register an offense for pluck without select" do
+    expect_no_offenses(<<~RUBY)
+      User.pluck(:id)
+    RUBY
+  end
+
+  it "does not register an offense for pluck without a receiver" do
+    expect_no_offenses(<<~RUBY)
+      pluck(:id)
+    RUBY
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Gusto/PluckOnSelect` cop that flags `.pluck` chained on `.select`
- When chained, `.pluck` ignores any directives passed to `.select` (column aliases, `DISTINCT`, block filters), which silently produces incorrect results
- Ported from zenpayroll's `Rails/PluckOnSelect`; renamed to `Gusto/` namespace and Sorbet annotation removed

## Test Plan

- [x] 9 spec cases covering simple offense, alias, DISTINCT, deeper receiver chains, block filter, safe navigation (`&.`), and no-offense cases
- [x] 100% line and branch coverage (`bundle exec rspec`)
- [x] Full suite passes (434 examples, 0 failures)
