### PR TITLE
feat: Ensure rubocop-gusto has access to CodeTeams everywhere it runs (RR-880)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-gusto (11.1.1)
+      code_teams
       lint_roller
       rubocop (>= 1.76)
       rubocop-performance
@@ -29,6 +30,8 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    code_teams (1.3.0)
+      sorbet-runtime
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
@@ -107,6 +110,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sorbet-runtime (0.6.13309)
     thor (1.5.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/rubocop-gusto.gemspec
+++ b/rubocop-gusto.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r(\Aexe/)) { |f| File.basename(f) }
 
+  spec.add_dependency "code_teams"
   spec.add_dependency "lint_roller"
   spec.add_dependency "rubocop", ">= 1.76"
   spec.add_dependency "rubocop-performance"


### PR DESCRIPTION
Adds `code_teams` as a runtime dependency so the `CodeTeams` module is available in every project that installs `rubocop-gusto`, not just this repo. Regenerates `Gemfile.lock` (pulls in `code_teams 1.3.0` + `sorbet-runtime`). Verified: bundle resolves, `CodeTeams` loads, rubocop clean, rspec green.

Jira: RR-880

🤖 Generated with [Claude Code](https://claude.com/claude-code)
