### PR TITLE
feat: add Gusto/SmartTodoTeam cop enforcing valid team in TODOs (RR-866)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       rubocop-rake
       rubocop-rspec
       rubocop-sorbet
+      smart_todo
       thor
 
 GEM
@@ -110,6 +111,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    smart_todo (1.11.0)
+      prism (~> 1.0)
     sorbet-runtime (0.6.13309)
     thor (1.5.0)
     tzinfo (2.0.6)

--- a/config/gusto_cops.yml
+++ b/config/gusto_cops.yml
@@ -107,6 +107,10 @@ Gusto/RspecDateTimeMock:
 Gusto/SidekiqParams:
   Description: 'Sidekiq perform methods cannot take keyword arguments.'
 
+Gusto/SmartTodoTeam:
+  Description: 'TODO comments must be SmartTodo-formatted and target a valid team (CodeTeams).'
+  Enabled: false
+
 Gusto/ToplevelConstants:
   Description: 'Prevents top-level constants from being defined outside of initializers.'
   Include:
@@ -136,3 +140,7 @@ Gusto/UsePaintNotColorize:
 
 Gusto/VcrRecordings:
   Description: 'VCR should be set to not record in tests. Use vcr: {record: :none}.'
+
+# We extend this via Gusto/SmartTodoTeam; don't let the upstream cop run standalone.
+SmartTodo/SmartTodoCop:
+  Enabled: false

--- a/lib/rubocop/cop/gusto/smart_todo_team.rb
+++ b/lib/rubocop/cop/gusto/smart_todo_team.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "smart_todo_cop" # defines RuboCop::Cop::SmartTodo::SmartTodoCop (also requires "smart_todo")
+require "code_teams"
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Enforces SmartTodo syntax (via the upstream `SmartTodo/SmartTodoCop`) and,
+      # in addition, requires every TODO's `to:` assignee to name a valid team as
+      # defined by CodeTeams (`config/teams/**/*.yml`).
+      #
+      # All of the upstream cop's failure modes are preserved verbatim via `super`.
+      # The only additional offense is raised when an otherwise-valid SmartTodo
+      # comment is assigned to an unknown team.
+      #
+      # @example
+      #   # bad - assigned to an unknown team
+      #   # TODO(on: date('2025-01-01'), to: 'NotATeam')
+      #   #   Remove this
+      #
+      #   # good - assigned to a team in config/teams
+      #   # TODO(on: date('2025-01-01'), to: 'Payroll')
+      #   #   Remove this
+      class SmartTodoTeam < ::RuboCop::Cop::SmartTodo::SmartTodoCop
+        TEAM_HELP = "TODO `to:` must name a valid team (see config/teams)."
+
+        # @param processed_source [RuboCop::ProcessedSource]
+        # @return [void]
+        def on_new_investigation
+          # Registers every existing SmartTodo offense. RuboCop dedupes offenses by
+          # source range (see Cop::Base#add_offense), so any comment flagged here
+          # silently swallows the duplicate team offense we might add below.
+          super
+
+          processed_source.comments.each do |comment|
+            next unless TODO_PATTERN.match?(comment.text)
+
+            # `is_a?(String)` guards CodeTeams.find's Sorbet signature, which raises on a
+            # non-string. Such assignees are already flagged by `super` (invalid assignee).
+            unknown = metadata(comment.text).assignees.select { |assignee| assignee.is_a?(String) && !CodeTeams.find(assignee) }
+            next if unknown.empty?
+
+            add_offense(comment, message: "Unknown team(s): #{unknown.join(', ')}. #{TEAM_HELP}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/gusto/smart_todo_team.rb
+++ b/lib/rubocop/cop/gusto/smart_todo_team.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   # TODO(on: date('2025-01-01'), to: 'Payroll')
       #   #   Remove this
       class SmartTodoTeam < ::RuboCop::Cop::SmartTodo::SmartTodoCop
-        TEAM_HELP = "TODO `to:` must name a valid team (see config/teams)."
+        TEAM_HELP = "TODO `to:` must name a valid team (see config/teams).  Match the human readable `name:` key (ex: 'Benefits Admin Transfers'), *not* a sluggified form."
 
         # @param processed_source [RuboCop::ProcessedSource]
         # @return [void]

--- a/rubocop-gusto.gemspec
+++ b/rubocop-gusto.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-rake"
   spec.add_dependency "rubocop-rspec"
   spec.add_dependency "rubocop-sorbet"
+  spec.add_dependency "smart_todo"
   spec.add_dependency "thor"
 end

--- a/spec/rubocop/cop/gusto/smart_todo_team_spec.rb
+++ b/spec/rubocop/cop/gusto/smart_todo_team_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe(RuboCop::Cop::Gusto::SmartTodoTeam, :config) do
   it("registers an offense when the TODO targets an unknown team") do
     expect_offense(<<~RUBY)
       # TODO(on: date('2025-01-01'), to: 'NotATeam')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown team(s): NotATeam. TODO `to:` must name a valid team (see config/teams).
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown team(s): NotATeam. TODO `to:` must name a valid team (see config/teams).  Match the human readable `name:` key (ex: 'Benefits Admin Transfers'), *not* a sluggified form.
     RUBY
   end
 

--- a/spec/rubocop/cop/gusto/smart_todo_team_spec.rb
+++ b/spec/rubocop/cop/gusto/smart_todo_team_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "code_teams/testing"
+
+# Installs CodeTeams::Testing's RSpec helpers (`code_team_with_config`) and the
+# per-example cache reset. Idempotent.
+CodeTeams::Testing.enable!
+
+RSpec.describe(RuboCop::Cop::Gusto::SmartTodoTeam, :config) do
+  before { code_team_with_config(name: "Payroll") }
+
+  it("does not register an offense when the TODO targets a valid team") do
+    expect_no_offenses(<<~RUBY)
+      # TODO(on: date('2025-01-01'), to: 'Payroll')
+      x = 1
+    RUBY
+  end
+
+  it("registers an offense when the TODO targets an unknown team") do
+    expect_offense(<<~RUBY)
+      # TODO(on: date('2025-01-01'), to: 'NotATeam')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown team(s): NotATeam. TODO `to:` must name a valid team (see config/teams).
+    RUBY
+  end
+
+  it("does not register a team offense for non-TODO comments") do
+    expect_no_offenses(<<~RUBY)
+      # just a regular comment, not a TODO
+      x = 1
+    RUBY
+  end
+
+  # Inherited SmartTodo failure modes still fire via `super`. A non-string assignee
+  # is flagged by the upstream cop; our team check skips it (is_a?(String) is false),
+  # so there is exactly one offense (the upstream one), not a duplicate.
+  it("preserves the upstream offense for a non-string assignee") do
+    expect_offense(<<~RUBY)
+      # TODO(on: date('2025-01-01'), to: 123)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid event assignee. This method only accepts strings. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
+    RUBY
+  end
+
+  # A lowercase tag is flagged by the upstream cop. Even though the team is unknown,
+  # RuboCop dedupes by range, so only the upstream offense is reported (added first).
+  it("preserves the upstream offense for a lowercase tag and does not double-report") do
+    expect_offense(<<~RUBY)
+      # todo(on: date('2025-01-01'), to: 'NotATeam')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't write regular TODO comments. Write SmartTodo compatible syntax comments. For more info please look at https://github.com/Shopify/smart_todo/wiki/Syntax
+    RUBY
+  end
+end


### PR DESCRIPTION
## RR-866

Adds an org-wide cop, **`Gusto/SmartTodoTeam`**, extending the upstream `SmartTodo/SmartTodoCop`.

- Calls `super`, so **all existing SmartTodo failure modes are preserved**.
- **Adds one new failure mode:** a TODO is an offense if its `to:` assignee isn't a valid team (exact-name `CodeTeams.find` against `config/teams`).
- Relies on RuboCop's range-based offense dedup to avoid double-reporting comments the upstream checks already flag.
- Ships **disabled by default** (opt-in), like upstream; pins `SmartTodo/SmartTodoCop` off so it doesn't run standalone.
- Adds `smart_todo` as a runtime dependency.

New spec has 100% line + branch coverage; full suite and `rubocop` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)