### PR TITLE
feat: add Gusto/FeatureFlagConstants cop (RR-890)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
 InternalAffairs/OnSendWithoutOnCSend:
   Exclude:
     - 'lib/rubocop/cop/gusto/execute_migration.rb' # called on a class
+    - 'lib/rubocop/cop/gusto/feature_flag_constants.rb' # FeatureFlag is a constant; FeatureFlag&.active? is never written
     - 'lib/rubocop/cop/gusto/no_paperclip_or_attachable.rb' # called on a class body
     - 'lib/rubocop/cop/gusto/paperclip_or_attachable.rb' # called on a class body
     - 'lib/rubocop/cop/gusto/bootsnap_load_file.rb' # called only on classes

--- a/config/gusto_cops.yml
+++ b/config/gusto_cops.yml
@@ -43,6 +43,9 @@ Gusto/FactoryClassesOrModules:
   Include:
     - 'spec/**/factories/*.rb'
 
+Gusto/FeatureFlagConstants:
+  Description: 'FeatureFlag keys should be constants, not strings.'
+
 Gusto/MinByMaxBy:
   Description: 'Checks for the use of `min` or `max` with a proc. Corrects to `min_by` or `max_by`.'
   Safe: false

--- a/lib/rubocop/cop/gusto/feature_flag_constants.rb
+++ b/lib/rubocop/cop/gusto/feature_flag_constants.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Enforces that `FeatureFlag.active?` is called with a constant rather than a
+      # string literal. Defining flag keys as constants keeps them in one place,
+      # makes typos a load-time error instead of a silent always-off flag, and lets
+      # tools find every reference to a flag.
+      #
+      # `FeatureFlag` is a constant, so it is never nil and safe navigation
+      # (`FeatureFlag&.active?`) is never used; the cop only handles `on_send`.
+      #
+      # @example
+      #   # bad
+      #   FeatureFlag.active?("some_feature_flag")
+      #
+      #   # good
+      #   FeatureFlag.active?(SomeModule::SOME_FEATURE_FLAG)
+      class FeatureFlagConstants < Base
+        MSG = "FeatureFlag keys should be constants, not strings"
+        RESTRICT_ON_SEND = %i(active?).freeze
+
+        # @!method feature_flag_with_string?(node)
+        def_node_matcher :feature_flag_with_string?, <<~PATTERN
+          (send (const nil? :FeatureFlag) :active? (str _) ...)
+        PATTERN
+
+        def on_send(node)
+          add_offense(node) if feature_flag_with_string?(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/feature_flag_constants_spec.rb
+++ b/spec/rubocop/cop/gusto/feature_flag_constants_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gusto::FeatureFlagConstants, :config do
+  context "when FeatureFlag.active? is called with a string argument" do
+    it "registers an offense for double-quoted strings" do
+      expect_offense(<<~RUBY)
+        FeatureFlag.active?("some_feature_flag")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FeatureFlag keys should be constants, not strings
+      RUBY
+    end
+
+    it "registers an offense for single-quoted strings" do
+      expect_offense(<<~RUBY)
+        FeatureFlag.active?('some_feature_flag')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FeatureFlag keys should be constants, not strings
+      RUBY
+    end
+
+    it "registers an offense when nested in conditions" do
+      expect_offense(<<~RUBY)
+        if FeatureFlag.active?("nested_feature")
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FeatureFlag keys should be constants, not strings
+          do_something
+        end
+      RUBY
+    end
+
+    it "registers an offense when used in a ternary" do
+      expect_offense(<<~RUBY)
+        result = FeatureFlag.active?("ternary_feature") ? true : false
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FeatureFlag keys should be constants, not strings
+      RUBY
+    end
+  end
+
+  context "when FeatureFlag.active? is called with a constant" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        FeatureFlag.active?(MY_FEATURE_FLAG_CONSTANT)
+      RUBY
+    end
+
+    it "does not register an offense for namespaced constants" do
+      expect_no_offenses(<<~RUBY)
+        FeatureFlag.active?(MyModule::MY_CONSTANT)
+      RUBY
+    end
+  end
+
+  context "when FeatureFlag.active? is called with a variable" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        feature_key = "some_feature"
+        FeatureFlag.active?(feature_key)
+      RUBY
+    end
+  end
+
+  context "when active? is called on a different receiver" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        SomethingElse.active?("some_feature_flag")
+      RUBY
+    end
+
+    it "does not register an offense for a bare active? call" do
+      expect_no_offenses(<<~RUBY)
+        active?("some_feature_flag")
+      RUBY
+    end
+  end
+
+  context "when FeatureFlag is used with a different method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        FeatureFlag.enabled?("some_feature_flag")
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a new cop `Gusto/FeatureFlagConstants` that flags `FeatureFlag.active?` calls made with a string literal instead of a constant.

```ruby
# bad
FeatureFlag.active?("some_feature_flag")

# good
FeatureFlag.active?(SomeModule::SOME_FEATURE_FLAG)
```

Defining flag keys as constants keeps them in one place, turns a typo into a load-time error instead of a silently-always-off flag, and lets tooling find every reference to a flag.

## Why

`FeatureFlag` is a Gusto-wide concept, and a version of this cop has been maintained downstream in a consuming app. Promoting it here lets that app drop its local copy and inherit the shared, tested version. Tracked by RR-890.

## Implementation notes

- `RESTRICT_ON_SEND = %i(active?)` and a `def_node_matcher` with a `# @!method` annotation, per the gem's cop-authoring conventions.
- The cop only handles `on_send`. `FeatureFlag` is a constant, so it is never nil and `FeatureFlag&.active?` is never written; rather than add a meaningless `on_csend` alias, the file is added to the annotated `InternalAffairs/OnSendWithoutOnCSend` exclude in `.rubocop.yml` (matching how other constant/class-target cops in this gem are handled).
- Registered in `config/gusto_cops.yml` with a `Description`.

## Test coverage

`spec/rubocop/cop/gusto/feature_flag_constants_spec.rb` covers double/single-quoted strings, nested conditions, and ternaries as offenses, and constants, namespaced constants, and variables as non-offenses. Non-`FeatureFlag` receivers, bare `active?`, and other methods on `FeatureFlag` are verified as non-offenses. Suite is at 100% line and branch coverage.
