### PR TITLE
feat: add Gusto/ConstantSafety cop

### DIFF
--- a/config/gusto_cops.yml
+++ b/config/gusto_cops.yml
@@ -12,6 +12,9 @@
 Gusto/BootsnapLoadFile:
   Description: 'Do not use Bootsnap to load files. Use `require` instead.'
 
+Gusto/ConstantSafety:
+  Description: 'Flags safe navigation (`&.`) on a constant (class/module or SCREAMING_CASE); constants are never nil, so `.` should be used instead.'
+
 Gusto/DatadogConstant:
   Exclude:
     # calling DataDog directly only allowed in initializers, its library, and tests

--- a/lib/rubocop/cop/gusto/constant_safety.rb
+++ b/lib/rubocop/cop/gusto/constant_safety.rb
@@ -7,8 +7,8 @@ module RuboCop
       # class/module constants (`Model&.find`) and SCREAMING_CASE constants
       # (`CONST&.each`).
       #
-      # A constant reference is never `nil` — an undefined constant raises
-      # `NameError` before the call is even attempted — so the safe navigation
+      # A constant reference is never `nil`, an undefined constant raises
+      # `NameError` before the call is even attempted, so the safe navigation
       # operator is always redundant. Use the plain `.` operator instead.
       #
       # @example

--- a/lib/rubocop/cop/gusto/constant_safety.rb
+++ b/lib/rubocop/cop/gusto/constant_safety.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gusto
+      # Flags safe navigation (`&.`) called on a constant, covering both
+      # class/module constants (`Model&.find`) and SCREAMING_CASE constants
+      # (`CONST&.each`).
+      #
+      # A constant reference is never `nil` — an undefined constant raises
+      # `NameError` before the call is even attempted — so the safe navigation
+      # operator is always redundant. Use the plain `.` operator instead.
+      #
+      # @example
+      #   # bad
+      #   Model&.find(id)
+      #   ENTITY_TYPES&.each { |type| type.to_s }
+      #   Foo::Bar&.call
+      #   ::Foo&.call
+      #
+      #   # good
+      #   Model.find(id)
+      #   ENTITY_TYPES.each { |type| type.to_s }
+      #   Foo::Bar.call
+      #   ::Foo.call
+      class ConstantSafety < Base
+        extend AutoCorrector
+
+        MSG = "Do not use safe navigation (`&.`) on a constant; constants are never `nil`, so use `.` instead."
+
+        def on_csend(node)
+          return unless node.receiver.const_type?
+
+          add_offense(node.loc.dot) do |corrector|
+            corrector.replace(node.loc.dot, ".")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/gusto/constant_safety_spec.rb
+++ b/spec/rubocop/cop/gusto/constant_safety_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Gusto::ConstantSafety, :config do
+  context "when safe navigation is called on a class/module constant" do
+    it "registers an offense and autocorrects to plain navigation" do
+      expect_offense(<<~RUBY)
+        Model&.find(id)
+             ^^ Do not use safe navigation (`&.`) on a constant; constants are never `nil`, so use `.` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model.find(id)
+      RUBY
+    end
+  end
+
+  context "when safe navigation is called on a SCREAMING_CASE constant" do
+    it "registers an offense and autocorrects to plain navigation" do
+      expect_offense(<<~RUBY)
+        ENTITY_TYPES&.each { |type| type.to_s }
+                    ^^ Do not use safe navigation (`&.`) on a constant; constants are never `nil`, so use `.` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ENTITY_TYPES.each { |type| type.to_s }
+      RUBY
+    end
+  end
+
+  context "when safe navigation is called on a namespaced constant" do
+    it "registers an offense and autocorrects to plain navigation" do
+      expect_offense(<<~RUBY)
+        Foo::Bar&.call
+                ^^ Do not use safe navigation (`&.`) on a constant; constants are never `nil`, so use `.` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Foo::Bar.call
+      RUBY
+    end
+  end
+
+  context "when safe navigation is called on a top-level (cbase) constant" do
+    it "registers an offense and autocorrects to plain navigation" do
+      expect_offense(<<~RUBY)
+        ::Foo&.call
+             ^^ Do not use safe navigation (`&.`) on a constant; constants are never `nil`, so use `.` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ::Foo.call
+      RUBY
+    end
+  end
+
+  context "when safe navigation is called on a non-constant receiver" do
+    it "does not register an offense for a local variable or method call" do
+      expect_no_offenses(<<~RUBY)
+        foo&.bar
+        user.account&.name
+      RUBY
+    end
+  end
+
+  context "when a constant uses plain (non-safe) navigation" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Model.find(id)
+        ENTITY_TYPES.each { |type| type.to_s }
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Gusto/ConstantSafety`, upstreamed from zenpayroll's `components/custom_cops`, so the rule is available to every app that uses `rubocop-gusto`.

The cop flags redundant safe navigation (`&.`) on a **constant** receiver and autocorrects it to plain `.`:

- class/module constants — `Model&.find(id)`
- SCREAMING_CASE constants — `ENTITY_TYPES&.each { ... }`
- namespaced constants — `Foo::Bar&.call`
- top-level (cbase) constants — `::Foo&.call`

A constant reference is never `nil` — an undefined constant raises `NameError` before the call is even attempted — so the safe-navigation operator is always redundant.

## Motivation

In  repos with custom cops, `InternalAffairs/OnSendWithoutOnCSend` kept flagging cops whose receiver is always a constant (e.g. `FeatureFlagConstants` matching `FeatureFlag.active?`). Aliasing `on_csend` there is meaningless — `FeatureFlag&.active?` is nonsensical safe navigation. The right fix is a single, general cop that flags the redundant `&.`-on-a-constant everywhere, rather than per-cop workarounds. 

Promoting it here lets all repos consume it, as well as anyone else using this plugin.

## Test plan
- [x] `bundle exec rspec spec/rubocop/cop/gusto/constant_safety_spec.rb` — 6 examples, 0 failures (offense + autocorrect for each constant form, no offense for non-constant receivers or plain `.`)
- [x] `bundle exec rubocop lib/rubocop/cop/gusto/constant_safety.rb spec/rubocop/cop/gusto/constant_safety_spec.rb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
