### PR TITLE
fix: remove git dependency from Gusto/UnreferencedLet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,15 @@ bundle exec rubocop-gusto init
 4. Add an entry to `config/default.yml` with at minimum a `Description:` key, then run `bundle exec rubocop-gusto sort config/default.yml`.
 5. Create a corresponding spec in `spec/rubocop/cop/gusto/<cop_name>_spec.rb`.
 
+## No git dependency in cops
+
+Cops run in consuming projects' CI, editor integrations, and other environments that are not
+guaranteed to be a git work tree (or to have `git` installed at all). Never shell out to `git`
+(e.g. `git ls-files`, `Open3.capture2("git", ...)`) from a cop, either directly or via a helper
+it calls at runtime. A non-repo working directory makes `git` commands fail, and — because
+stderr is inherited by default — this prints `fatal: not a git repository` noise into the host
+process's logs even when the failure is handled. Use `Dir.glob` or other filesystem APIs instead.
+
 ## Writing cop specs
 
 **100% line and branch coverage is required.** `.simplecov` enforces this on every run — a branch coverage failure will abort the suite. Never use `:nocov:`.

--- a/lib/rubocop/cop/gusto/unreferenced_let.rb
+++ b/lib/rubocop/cop/gusto/unreferenced_let.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
 require "rubocop-rspec"
 
 module RuboCop
@@ -71,10 +70,7 @@ module RuboCop
         IDENTIFIER_IN_STRING = /[A-Za-z_]\w*[!?]?/
         MSG = "Remove unreferenced `let(:%{name})` -- its name is never used, so the block never runs."
         RESTRICT_ON_SEND = %i(let).freeze
-        # The glob and the pathspec encode the SAME set of files two ways: `Dir.glob` (fallback) and
-        # a regexp filter over `git ls-files` output. Keep them in sync if either changes.
         SUPPORT_FILES_GLOB = "**/spec/support/**/*.rb"
-        SUPPORT_FILES_PATHSPEC = %r{(?:\A|/)spec/support/.+\.rb\z}
 
         # The name symbol of any definition (`let`/`let!`/`subject`) in any block form -- used to
         # count how many times a name is defined, so override / `super` chains (including a
@@ -91,25 +87,11 @@ module RuboCop
             @framework_let_names ||= scan_framework_let_names(support_file_paths)
           end
 
-          # Enumerate `spec/support/**/*.rb`. Prefer `git ls-files` (reads the git index, skipping
-          # untracked trees like `node_modules`): a leading-`**` `Dir.glob` walks the entire
-          # repository and costs seconds, while reading the index costs tens of milliseconds. Fall
-          # back to `Dir.glob` when not in a git work tree or `git` is unavailable.
-          #
-          # Tradeoff: an untracked (brand-new, uncommitted) `spec/support/*.rb` override is invisible
-          # to `git ls-files`. In that narrow window its contract names are not exempted; once
-          # committed it is seen like any other support file.
+          # Enumerate `spec/support/**/*.rb`. No git dependency: some environments (e.g. a build
+          # step's working directory) are not a git work tree at all, and shelling out to `git`
+          # there is unreliable and noisy.
           def support_file_paths
-            git_tracked_support_files || ::Dir.glob(SUPPORT_FILES_GLOB)
-          end
-
-          def git_tracked_support_files
-            output, status = ::Open3.capture2("git", "ls-files", "-z")
-            return nil unless status.success?
-
-            output.split("\x0").grep(SUPPORT_FILES_PATHSPEC)
-          rescue ::SystemCallError
-            nil
+            ::Dir.glob(SUPPORT_FILES_GLOB)
           end
 
           def scan_framework_let_names(paths)

--- a/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
+++ b/spec/rubocop/cop/gusto/unreferenced_let_spec.rb
@@ -407,36 +407,7 @@ RSpec.describe RuboCop::Cop::Gusto::UnreferencedLet, :config do
   end
 
   describe "support-file enumeration" do
-    it "selects spec/support .rb paths from the git index" do
-      status = instance_double(Process::Status, success?: true)
-      output = ["packs/a/spec/support/helper.rb", "lib/y.rb", "spec/support/root.rb", "spec/supportive/no.rb", ""].join("\x0")
-      allow(Open3).to receive(:capture2).with("git", "ls-files", "-z").and_return([output, status])
-
-      expect(described_class.git_tracked_support_files)
-        .to contain_exactly("packs/a/spec/support/helper.rb", "spec/support/root.rb")
-    end
-
-    it "returns nil when git ls-files exits non-zero" do
-      status = instance_double(Process::Status, success?: false)
-      allow(Open3).to receive(:capture2).and_return(["", status])
-
-      expect(described_class.git_tracked_support_files).to be_nil
-    end
-
-    it "returns nil when git is unavailable" do
-      allow(Open3).to receive(:capture2).and_raise(Errno::ENOENT)
-
-      expect(described_class.git_tracked_support_files).to be_nil
-    end
-
-    it "uses the git-tracked files when available" do
-      allow(described_class).to receive(:git_tracked_support_files).and_return(["spec/support/tracked.rb"])
-
-      expect(described_class.support_file_paths).to eq(["spec/support/tracked.rb"])
-    end
-
-    it "falls back to Dir.glob when git tracking is unavailable" do
-      allow(described_class).to receive(:git_tracked_support_files).and_return(nil)
+    it "enumerates spec/support .rb paths via Dir.glob without touching git" do
       allow(Dir).to receive(:glob).with(RuboCop::Cop::Gusto::UnreferencedLet::SUPPORT_FILES_GLOB).and_return(["spec/support/from_glob.rb"])
 
       expect(described_class.support_file_paths).to eq(["spec/support/from_glob.rb"])


### PR DESCRIPTION
## Summary
- `Gusto/UnreferencedLet` shelled out to `git ls-files` as a fast-path for enumerating `spec/support/**/*.rb` files. In working directories that aren't a git work tree (e.g. some CI build steps), this printed `fatal: not a git repository` to stderr for every git call, spamming CI logs (see internal Slack thread from Ngan Pham/Scott Macfarlane/David Corson-Knowles, 2026-07-17).
- Removed the git-backed lookup entirely — `support_file_paths` now always uses `Dir.glob`, so the cop has no dependency on git being installed or the cwd being a repo.
- Updated `AGENTS.md` with a new "No git dependency in cops" section so future cops don't reintroduce a git dependency.

## Test plan
- [x] `bin/rspec` — 456 examples, 0 failures, 100% line/branch coverage
- [x] `bin/rubocop` on changed files — no offenses