### PR TITLE
feat: enable Sorbet/RedundantTLetForLiteral and bump rubocop-sorbet for RedundantTLet cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       rubocop-performance
       rubocop-rake
       rubocop-rspec
-      rubocop-sorbet
+      rubocop-sorbet (>= 0.13.0)
       smart_todo
       thor
 
@@ -101,7 +101,7 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
-    rubocop-sorbet (0.12.0)
+    rubocop-sorbet (0.13.2)
       lint_roller
       rubocop (>= 1.75.2)
     ruby-progressbar (1.13.0)

--- a/config/default.yml
+++ b/config/default.yml
@@ -274,6 +274,11 @@ Sorbet/ForbidTUnsafe:
   # reorganizing the code over silently turning off the type checker.
   Enabled: true
 
+Sorbet/RedundantTLetForLiteral:
+  # Still marked pending upstream, we'd like to enable it now. Remove this
+  # override once it's no longer pending in rubocop-sorbet.
+  Enabled: true
+
 Sorbet/Refinement:
   # Still marked pending upstream, we contributed this and enable it here.
   Enabled: true

--- a/rubocop-gusto.gemspec
+++ b/rubocop-gusto.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rake"
   spec.add_dependency "rubocop-rspec"
-  spec.add_dependency "rubocop-sorbet"
+  spec.add_dependency "rubocop-sorbet", ">= 0.13.0"
   spec.add_dependency "smart_todo"
   spec.add_dependency "thor"
 end


### PR DESCRIPTION
## Summary
- Bump the `rubocop-sorbet` dependency floor to `>= 0.13.0`, the first release that ships `Sorbet/RedundantTLet` and `Sorbet/RedundantTLetForLiteral`.
- `Sorbet/RedundantTLet` is already `Enabled: true` by default upstream in 0.13.0+, so no override is needed — bumping the gem is enough to turn it on.
- `Sorbet/RedundantTLetForLiteral` is still `Enabled: pending` upstream, so it's explicitly enabled in `config/default.yml` (same pattern as `Sorbet/Refinement`), with a comment noting the override should be removed once it's no longer pending.

## Test plan
- [x] `bundle exec rubocop-gusto sort config/default.yml`
- [x] `bundle exec rubocop --only Sorbet/RedundantTLet,Sorbet/RedundantTLetForLiteral` — no new offenses in this repo
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rspec` — 460 examples, 0 failures, 100% line/branch coverage