### PR TITLE
fix: scope Gusto/VcrRecordings to specs

### DIFF
--- a/config/gusto_cops.yml
+++ b/config/gusto_cops.yml
@@ -164,6 +164,8 @@ Gusto/UsePaintNotColorize:
 
 Gusto/VcrRecordings:
   Description: 'VCR should be set to not record in tests. Use vcr: {record: :none}.'
+  Include:
+    - '**/spec/**/*'
 
 # We extend this via Gusto/SmartTodoTeam; don't let the upstream cop run standalone.
 SmartTodo/SmartTodoCop:


### PR DESCRIPTION
## What

Give `Gusto/VcrRecordings` the same `Include: ['**/spec/**/*']` that `Gusto/DescribedClassConstantReference`, `Gusto/RedundantSpecHelperRequire`, and `Gusto/RspecDateTimeMock` already carry.

## Why

The cop ships with no `Include`, so `on_pair` fires on **every hash pair in the consuming project**, and each invocation runs:

```ruby
def vcr_setting?(node)
  node.parent.parent.source.include?("vcr")
end
```

`node.parent.parent.source` materialises the whole source of the enclosing block as a String, per pair. That is the most expensive thing this cop does, and it is done to answer a question that can only be `true` in a spec — VCR is configured through RSpec metadata.

I profiled this with a `Commissioner` callback timer on a large internal Rails codebase, over a stratified sample of its files. In that run the cop took **4.7% of all cop callback time**, averaged **~30 `on_pair` invocations per file inspected**, and had the highest per-invocation cost of any high-frequency cop measured. The clear majority of that project's files are outside a `spec/` directory, so this `Include` drops most of those invocations outright.

## Blast radius

None for the project I measured: a full `--auto-gen-config` pass over its entire tree generates no `Gusto/VcrRecordings` entry at all, i.e. the cop reports zero offenses there today, inside specs or out.

Consuming projects that do have offenses only lose ones outside a `spec/` directory. Per AGENTS.md, a change in the set of violations a cop reports is not by itself a breaking change, so this ships as `fix:` rather than `feat!:`.

## Not in this PR

Two things I noticed in `vcr_setting?` while measuring, both worth their own change:

1. The substring search can avoid the allocation entirely — `processed_source.buffer.source.index("vcr", range.begin_pos)` compared against `range.end_pos` is the same test without building the String.
2. `node.parent.parent` is `nil` when a `pair` sits in a bare top-level hash literal, so `.source` raises `NoMethodError` there. Under `--auto-gen-config` a cop error fails the whole run, so this is worth a `&.`.

## Verification

- `bundle exec rspec` — 610 examples, 0 failures, 100% line (1041/1041) and branch (415/415) coverage
- `bundle exec rubocop` — 94 files, no offenses
- In a consumer whose `.rubocop.yml` sets `inherit_mode: merge: - Include`, `bundle exec rubocop --show-cops Gusto/VcrRecordings` resolves to exactly `Include: ['**/spec/**/*']`, confirming the merge does not re-broaden it
