### PR TITLE
fix: hold release-gem at v1.2.0 so gem publishing works again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,5 +28,11 @@ updates:
       all-actions:
         patterns:
           - "*"
+    ignore:
+      # release-gem v1.3.0+ pin rubygems/configure-rubygems-credentials v2.x, a SHA
+      # that is not on Gusto's GitHub Actions allowlist. Bumping it silently breaks
+      # gem publishing: v11.4.0 through v11.7.1 were tagged but never released.
+      # Drop this ignore once the newer SHA is allowlisted.
+      - dependency-name: "rubygems/release-gem"
     commit-message:
       prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,14 @@ jobs:
         run: bundle install --jobs 4
 
       # Release
-      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
+      # Deliberately held at v1.2.0. release-gem v1.3.0+ pin
+      # rubygems/configure-rubygems-credentials v2.x, and that SHA is not on Gusto's
+      # GitHub Actions allowlist, so the job is rejected at action-resolution time and
+      # never publishes. v11.4.0 through v11.7.1 were all tagged but never released to
+      # rubygems.org because of this. v1.2.0 is the newest release-gem that still pins
+      # configure-rubygems-credentials v1.0.0, which is allowlisted.
+      # Do not bump until the newer SHA is added to the enterprise allowlist.
+      - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
 
       - name: Upload gem to release
         continue-on-error: true  # May fail due to IP allow list restrictions


### PR DESCRIPTION
## The gem has not published since v11.3.0

`rubygems/release-gem` v1.3.0+ pin `rubygems/configure-rubygems-credentials` **v2.x**, and that SHA is not on Gusto's GitHub Actions allowlist. The release job is rejected at action-resolution time — before any step runs — so nothing is ever pushed to rubygems.org. The runs die in 7–15s.

Dependabot bumped release-gem v1.2.0 → v1.4.0 in #147 (2026-07-01). Every release since has failed identically:

| Tag | Released | Release Gem run |
|---|---|---|
| v11.4.0 | 2026-07-13 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/29274407937) |
| v11.5.0 | 2026-07-14 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/29375023568) |
| v11.6.0 | 2026-07-22 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/29948697396) |
| v11.6.1 | 2026-07-28 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/30387658502) |
| v11.7.0 | 2026-08-14 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/31822922645) |
| v11.7.1 | 2026-08-18 | [failed](https://github.com/Gusto/rubocop-gusto/actions/runs/32083156972) |

All six have git tags and GitHub releases, so they *look* shipped. But the newest version installable from rubygems.org or the Cloudsmith mirror is still **11.3.0**:

```
$ curl -s https://rubygems.org/api/v1/versions/rubocop-gusto.json | jq -r '.[0].number'
11.3.0
```

## Why this matters right now

[Gusto/zenpayroll#362170](https://github.com/Gusto/zenpayroll/pull/362170) deletes zenpayroll's local copies of `Gusto/ConstantSafety`, `Gusto/Sorbet/PredicateBooleanReturn` and `Gusto/SuddenAssociations` on the premise that this gem now supplies them. It cannot go green: no *published* version contains any of the three, so there is no version to bump to. That PR is currently pinned to this repo's git tag as a workaround.

## The change

Hold `release-gem` at **v1.2.0** — the newest release that still pins `configure-rubygems-credentials` **v1.0.0**, the SHA in use the last time a release published successfully (v11.3.0, 2026-06-29). Dependabot is told to ignore `release-gem` so a future bump cannot silently re-break publishing.

## Caveats

- **This cannot be verified by PR CI.** `Release Gem` only runs on `release: published`, so the first real proof is the next release. The evidence for v1.2.0 working is that v11.3.0 published with exactly this pin.
- The allowlist itself is truncated in the failure logs, so I could not read it directly to confirm the v1.0.0 SHA is still permitted — only that it was permitted on 2026-06-29.
- **Getting the v2.x SHA allowlisted is the durable fix**; this restores publishing in the meantime and the `ignore` should be dropped once that happens.

Merging this as a `fix:` lets release-please cut a patch release, which will publish the six versions' worth of accumulated cops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)